### PR TITLE
gpu/drm: hisilicon: Correct 720P's pixel clock to fix 720p didn't work at some monitors

### DIFF
--- a/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
@@ -765,7 +765,7 @@ static void hisi_drm_encoder_mode_set(struct drm_encoder *encoder,
 	vm->hsync_len = mode->hsync_end - mode->hsync_start;
 
 	/* laneBitRate >= pixelClk*24/lanes */
-	dsi->dphy_freq = vm->pixelclock*24/dsi->lanes + 20;
+	dsi->dphy_freq = vm->pixelclock*24/dsi->lanes;
 
 	vm->flags = 0;
 	if (mode->flags & DRM_MODE_FLAG_PHSYNC)
@@ -853,7 +853,7 @@ static int hisi_get_default_modes(struct drm_connector *connector)
 	}
 
 	mode->vrefresh = 60;
-	mode->clock = 75000;
+	mode->clock = 74175;
 	mode->hdisplay = 1280;
 	mode->hsync_start = 1500;
 	mode->hsync_end = 1540;
@@ -882,12 +882,11 @@ static int hisi_dsi_get_modes(struct drm_connector *connector)
 	if (sfuncs && sfuncs->get_modes)
 		count = sfuncs->get_modes(encoder, connector);
 
-	DRM_DEBUG_DRIVER("exit success. count=%d\n", count);
 #if USE_DEFAULT_720P_MODE
-	return hisi_get_default_modes(connector);
-#else
-	return count;
+	count += hisi_get_default_modes(connector);
 #endif
+	DRM_DEBUG_DRIVER("exit success. count=%d\n", count);
+	return count;
 }
 
 static struct drm_encoder *

--- a/drivers/gpu/drm/i2c/adv7533.c
+++ b/drivers/gpu/drm/i2c/adv7533.c
@@ -186,7 +186,7 @@ static void adv7533_set_config_csc(struct adv7533 *adv7533,
 	if (adv7533->edid)
 		config.hdmi_mode = drm_detect_hdmi_monitor(adv7533->edid);
 	else
-		config.hdmi_mode = true; /* HDMI as default */
+		config.hdmi_mode = false;
 
 	hdmi_avi_infoframe_init(&config.avi_infoframe);
 


### PR DESCRIPTION
Signed-off-by: Xinliang Liu z.liuxinliang@huawei.com
