### PR TITLE
gpu/drm: hisilicon: If use default 720p then let connector's status as c...

### DIFF
--- a/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
@@ -824,7 +824,11 @@ hisi_dsi_detect(struct drm_connector *connector, bool force)
 		status = sfuncs->detect(encoder, connector);
 
 	DRM_DEBUG_DRIVER("exit success. status=%d\n", status);
+#if USE_DEFAULT_720P_MODE
+	return connector_status_connected;
+#else
 	return status;
+#endif
 }
 
 static void hisi_dsi_connector_destroy(struct drm_connector *connector)


### PR DESCRIPTION
...onnected

This commit make that there is no need to connect HDMI cable to the monitor when kernel startup.
Before hot-plug feature is available, this is maybe needed.
Signed-off-by: Xinliang Liu z.liuxinliang@huawei.com
