### PR TITLE
arm64: dts: reserve memory region for mcu firmware

### DIFF
--- a/arch/arm64/boot/dts/hi6220-hikey.dts
+++ b/arch/arm64/boot/dts/hi6220-hikey.dts
@@ -7,6 +7,8 @@
 
 /dts-v1/;
 
+/memreserve/ 0x05E00000 0x00100000;
+
 #include "hikey-pinctrl.dtsi"
 #include "hikey-gpio.dtsi"
 #include "hi6220.dtsi"


### PR DESCRIPTION
The mcu firmware will use the memory region 0x0010_0000@0x05E0_0000;
so reserve this region in dts to make sure kernel will not corrupt
this memory region.

Signed-off-by: Leo Yan leo.yan@linaro.org
