### PR TITLE
mmc: dw_mmc: correct bus_hz

### DIFF
--- a/drivers/mmc/host/dw_mmc.c
+++ b/drivers/mmc/host/dw_mmc.c
@@ -2655,9 +2655,9 @@ int dw_mci_probe(struct dw_mci *host)
 			goto err_clk_biu;
 		}
 
-		host->bus_hz = clk_get_rate(host->ciu_clk);
 	}
 
+	host->bus_hz = clk_get_rate(host->biu_clk);
 	if (!host->bus_hz) {
 		dev_err(host->dev,
 			"Platform data must supply bus speed\n");


### PR DESCRIPTION
fix typo introduced from commit 0f7950e606af
(mmc: dw_mmc: fix warning of clk_prepare_enable/clk_disable_unprepare)

host->bus_hz should be biu_clk, which has been set to 25M

Signed-off-by: Zhangfei Gao zhangfei.gao@linaro.org
