### PR TITLE
Polish pinctrl

### DIFF
--- a/arch/arm64/boot/dts/hi6220-hikey.dts
+++ b/arch/arm64/boot/dts/hi6220-hikey.dts
@@ -47,44 +47,15 @@
 		};
 
 		uart1: uart@f7111000 {
-			pinctrl-names = "default", "idle";
-			pinctrl-0 = <&UART1_CTS_N_pmx_func
-			             &UART1_CTS_N_cfg_func
-			             &UART1_RTS_N_pmx_func
-				     &UART1_RTS_N_cfg_func
-				     &UART1_RXD_pmx_func
-				     &UART1_RXD_cfg_func
-				     &UART1_TXD_pmx_func
-				     &UART1_TXD_cfg_func>;
-			pinctrl-1 = <&UART1_CTS_N_pmx_idle
-			             &UART1_CTS_N_cfg_idle
-			             &UART1_RTS_N_pmx_idle
-				     &UART1_RTS_N_cfg_idle
-				     &UART1_RXD_pmx_idle
-				     &UART1_RXD_cfg_idle
-				     &UART1_TXD_pmx_idle
-				     &UART1_TXD_cfg_idle>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&uart1_pmx_func
+				     &uart1_cfg_func1 &uart1_cfg_func2>;
 			status = "ok";
 		};
 
 		uart2: uart@f7112000 {
-			pinctrl-names = "default", "idle";
-			pinctrl-0 = <&UART2_CTS_N_pmx_func
-			             &UART2_CTS_N_cfg_func
-			             &UART2_RTS_N_pmx_func
-				     &UART2_RTS_N_cfg_func
-				     &UART2_RXD_pmx_func
-				     &UART2_RXD_cfg_func
-				     &UART2_TXD_pmx_func
-				     &UART2_TXD_cfg_func>;
-			pinctrl-1 = <&UART2_CTS_N_pmx_idle
-			             &UART2_CTS_N_cfg_idle
-			             &UART2_RTS_N_pmx_idle
-				     &UART2_RTS_N_cfg_idle
-				     &UART2_RXD_pmx_idle
-				     &UART2_RXD_cfg_idle
-				     &UART2_TXD_pmx_idle
-				     &UART2_TXD_cfg_idle>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&uart2_pmx_func &uart2_cfg_func>;
 			status = "ok";
 		};
 	};
@@ -92,47 +63,9 @@
 	dwmmc_0: dwmmc0@f723d000 {
 		bus-width = <0x8>;
 		vmmc-supply = <&ldo19>;
-		pinctrl-names = "default","idle";
-		pinctrl-0 = <&EMMC_CLK_pmx_func
-			     &EMMC_CLK_cfg_func
-			     &EMMC_CMD_pmx_func
-			     &EMMC_CMD_cfg_func
-			     &EMMC_DATA0_pmx_func
-			     &EMMC_DATA0_cfg_func
-			     &EMMC_DATA1_pmx_func
-			     &EMMC_DATA1_cfg_func
-			     &EMMC_DATA2_pmx_func
-			     &EMMC_DATA2_cfg_func
-			     &EMMC_DATA3_pmx_func
-			     &EMMC_DATA3_cfg_func
-			     &EMMC_DATA4_pmx_func
-			     &EMMC_DATA4_cfg_func
-			     &EMMC_DATA5_pmx_func
-			     &EMMC_DATA5_cfg_func
-			     &EMMC_DATA6_pmx_func
-			     &EMMC_DATA6_cfg_func
-			     &EMMC_DATA7_pmx_func
-			     &EMMC_DATA7_cfg_func>;
-		pinctrl-1 = <&EMMC_CLK_pmx_idle
-			     &EMMC_CLK_cfg_idle
-			     &EMMC_CMD_pmx_idle
-			     &EMMC_CMD_cfg_idle
-			     &EMMC_DATA0_pmx_idle
-			     &EMMC_DATA0_cfg_idle
-			     &EMMC_DATA1_pmx_idle
-			     &EMMC_DATA1_cfg_idle
-			     &EMMC_DATA2_pmx_idle
-			     &EMMC_DATA2_cfg_idle
-			     &EMMC_DATA3_pmx_idle
-			     &EMMC_DATA3_cfg_idle
-			     &EMMC_DATA4_pmx_idle
-			     &EMMC_DATA4_cfg_idle
-			     &EMMC_DATA5_pmx_idle
-			     &EMMC_DATA5_cfg_idle
-			     &EMMC_DATA6_pmx_idle
-			     &EMMC_DATA6_cfg_idle
-			     &EMMC_DATA7_pmx_idle
-			     &EMMC_DATA7_cfg_idle>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&emmc_pmx_func &emmc_clk_cfg_func
+			     &emmc_cfg_func &emmc_rst_cfg_func>;
 	};
 
 	dwmmc_1: dwmmc1@f723e000 {
@@ -140,30 +73,8 @@
 		disable-wp;
 		cd-gpios = <&gpio1 0 1>;
 		pinctrl-names = "default", "idle";
-		pinctrl-0 = <&SD_CLK_pmx_func
-		             &SD_CLK_cfg_func
-			     &SD_CMD_pmx_func
-			     &SD_CMD_cfg_func
-			     &SD_DATA0_pmx_func
-			     &SD_DATA0_cfg_func
-			     &SD_DATA1_pmx_func
-			     &SD_DATA1_cfg_func
-			     &SD_DATA2_pmx_func
-			     &SD_DATA2_cfg_func
-			     &SD_DATA3_pmx_func
-			     &SD_DATA3_cfg_func>;
-		pinctrl-1 = <&SD_CLK_pmx_idle
-		             &SD_CLK_cfg_idle
-			     &SD_CMD_pmx_idle
-			     &SD_CMD_cfg_idle
-			     &SD_DATA0_pmx_idle
-			     &SD_DATA0_cfg_idle
-			     &SD_DATA1_pmx_idle
-			     &SD_DATA1_cfg_idle
-			     &SD_DATA2_pmx_idle
-			     &SD_DATA2_cfg_idle
-			     &SD_DATA3_pmx_idle
-			     &SD_DATA3_cfg_idle>;
+		pinctrl-0 = <&sd_pmx_func &sd_clk_cfg_func &sd_cfg_func>;
+		pinctrl-1 = <&sd_pmx_idle &sd_clk_cfg_idle &sd_cfg_idle>;
 	};
 
 	dwmmc_2: dwmmc2@f723f000 {
@@ -173,30 +84,8 @@
 		/* WL_EN */
 		vmmc-supply = <&wlan_en_reg>;
 		pinctrl-names = "default", "idle";
-		pinctrl-0 = <&SDIO_CLK_cfg_func
-			         &SDIO_CMD_cfg_func
-			         &SDIO_DATA0_cfg_func
-			         &SDIO_DATA1_cfg_func
-			         &SDIO_DATA2_cfg_func
-			         &SDIO_DATA3_cfg_func
-				 &SDIO_CLK_pmx_func
-			         &SDIO_CMD_pmx_func
-			         &SDIO_DATA0_pmx_func
-			         &SDIO_DATA1_pmx_func
-			         &SDIO_DATA2_pmx_func
-			         &SDIO_DATA3_pmx_func>;
-		pinctrl-1 = <&SDIO_CLK_cfg_idle
-			         &SDIO_CMD_cfg_idle
-			         &SDIO_DATA0_cfg_idle
-			         &SDIO_DATA1_cfg_idle
-			         &SDIO_DATA2_cfg_idle
-			         &SDIO_DATA3_cfg_idle
-				 &SDIO_CLK_pmx_idle
-			         &SDIO_CMD_pmx_idle
-			         &SDIO_DATA0_pmx_idle
-			         &SDIO_DATA1_pmx_idle
-			         &SDIO_DATA2_pmx_idle
-			         &SDIO_DATA3_pmx_idle>;
+		pinctrl-0 = <&sdio_pmx_func &sdio_clk_cfg_func &sdio_cfg_func>;
+		pinctrl-1 = <&sdio_pmx_idle &sdio_clk_cfg_idle &sdio_cfg_idle>;
 	};
 
 	wlcore {

--- a/arch/arm64/boot/dts/hi6220.dtsi
+++ b/arch/arm64/boot/dts/hi6220.dtsi
@@ -6,6 +6,7 @@
 
 #include <dt-bindings/clock/hi6220-clock.h>
 #include <dt-bindings/thermal/thermal.h>
+#include <dt-bindings/pinctrl/hisi.h>
 
 / {
 	cpus {
@@ -300,33 +301,34 @@
 			pinctrl-single,register-width = <32>;
 			pinctrl-single,function-mask = <7>;
 			pinctrl-single,gpio-range = <
-				&range 0  1  1
-				&range 2  24  1
-				&range 28  8  1
-				&range 43  21  1
-				&range 74  6  1
-				&range 80  42  0
-				&range 122  1  1
-				&range 126  33  1
+				&range  80  8 MUX_M0 /* gpio  3: [0..7] */
+				&range  88  8 MUX_M0 /* gpio  4: [0..7] */
+				&range  96  8 MUX_M0 /* gpio  5: [0..7] */
+				&range 104  8 MUX_M0 /* gpio  6: [0..7] */
+				&range 112  8 MUX_M0 /* gpio  7: [0..7] */
+				&range 120  2 MUX_M0 /* gpio  8: [0..1] */
+				&range   2  6 MUX_M1 /* gpio  8: [2..7] */
+				&range   8  8 MUX_M1 /* gpio  9: [0..7] */
+				&range   0  1 MUX_M1 /* gpio 10: [0]    */
+				&range  16  7 MUX_M1 /* gpio 10: [1..7] */
+				&range  23  3 MUX_M1 /* gpio 11: [0..2] */
+				&range  28  5 MUX_M1 /* gpio 11: [3..7] */
+				&range  33  3 MUX_M1 /* gpio 12: [0..2] */
+				&range  43  5 MUX_M1 /* gpio 12: [3..7] */
+				&range  48  8 MUX_M1 /* gpio 13: [0..7] */
+				&range  56  8 MUX_M1 /* gpio 14: [0..7] */
+				&range  74  6 MUX_M1 /* gpio 15: [0..5] */
+				&range 122  1 MUX_M1 /* gpio 15: [6]    */
+				&range 126  1 MUX_M1 /* gpio 15: [7]    */
+				&range 127  8 MUX_M1 /* gpio 16: [0..7] */
+				&range 135  8 MUX_M1 /* gpio 17: [0..7] */
+				&range 143  8 MUX_M1 /* gpio 18: [0..7] */
+				&range 151  8 MUX_M1 /* gpio 19: [0..7] */
 			>;
+
 			range: gpio-range {
 				#pinctrl-single,gpio-range-cells = <3>;
 			};
-
-			I2C2_SCL_pmx_func: I2C2_SCL_pmx_func {
-				pinctrl-single,pins = <0xF8    0x0>;
-			};
-			I2C2_SCL_pmx_idle: I2C2_SCL_pmx_idle {
-				pinctrl-single,pins = <0xF8    0x0>;
-			};
-
-			I2C2_SDA_pmx_func: I2C2_SDA_pmx_func {
-				pinctrl-single,pins = <0xFC    0x0>;
-			};
-			I2C2_SDA_pmx_idle: I2C2_SDA_pmx_idle {
-				pinctrl-single,pins = <0xFC    0x0>;
-			};
-
 		};
 
 		pmx1: pinmux@f7010800 {
@@ -335,32 +337,6 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			pinctrl-single,register-width = <32>;
-
-			I2C2_SCL_cfg_func: I2C2_SCL_cfg_func {
-			     pinctrl-single,pins = <0xFC  0>;
-			     pinctrl-single,bias-pulldown = <0 2 0 2>;
-			     pinctrl-single,bias-pullup = <0 1 0 1>;
-			     pinctrl-single,drive-strength = <0x00 0x70>;
-			};
-			I2C2_SCL_cfg_idle: I2C2_SCL_cfg_idle {
-			     pinctrl-single,pins = <0xFC  0>;
-			     pinctrl-single,bias-pulldown = <0 2 0 2>;
-			     pinctrl-single,bias-pullup = <0 1 0 1>;
-			     pinctrl-single,drive-strength = <0x00 0x70>;
-			};
-
-			I2C2_SDA_cfg_func: I2C2_SDA_cfg_func {
-			     pinctrl-single,pins = <0x100  0>;
-			     pinctrl-single,bias-pulldown = <0 2 0 2>;
-			     pinctrl-single,bias-pullup = <0 1 0 1>;
-			     pinctrl-single,drive-strength = <0x00 0x70>;
-			};
-			I2C2_SDA_cfg_idle: I2C2_SDA_cfg_idle {
-			     pinctrl-single,pins = <0x100  0>;
-			     pinctrl-single,bias-pulldown = <0 2 0 2>;
-			     pinctrl-single,bias-pullup = <0 1 0 1>;
-			     pinctrl-single,drive-strength = <0x00 0x70>;
-			};
 		};
 
 		pmx2: pinmux@f8001800 {
@@ -664,9 +640,8 @@
 			i2c-sda-hold-time-ns = <300>;
 			delay-reg = <0x0 0x0f8 0x0 4>;
 			reset-controller-reg = <0x330 0x334 0x338 3>;
-			pinctrl-names = "default", "idle";
-			pinctrl-0 = <&I2C2_SCL_pmx_func &I2C2_SDA_pmx_func &I2C2_SCL_cfg_func &I2C2_SDA_cfg_func>;
-			pinctrl-1 = <&I2C2_SCL_pmx_idle &I2C2_SDA_pmx_idle &I2C2_SCL_cfg_idle &I2C2_SDA_cfg_idle>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c2_pmx_func &i2c2_cfg_func>;
 			status = "ok";
 
 			adv7533: adv7533@39 {

--- a/arch/arm64/boot/dts/hikey-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/hikey-pinctrl.dtsi
@@ -2,2687 +2,624 @@
  * pinctrl dts fils for Hislicon HiKey development board
  *
  */
+#include <dt-bindings/pinctrl/hisi.h>
 
 / {
-   smb {
-    pmx0: pinmux@f7010000 {
-		BOOT_SEL_pmx_func: BOOT_SEL_pmx_func {
-                     pinctrl-single,pins = <0x0    0x0>;
-		};
-		BOOT_SEL_pmx_idle: BOOT_SEL_pmx_idle {
-                     pinctrl-single,pins = <0x0    0x0>;
-		};
-
-		PMU_SSI_pmx_func: PMU_SSI_pmx_func {
-                     pinctrl-single,pins = <0x4    0x0>;
-		};
-		PMU_SSI_pmx_idle: PMU_SSI_pmx_idle {
-                     pinctrl-single,pins = <0x4    0x0>;
-		};
-
-		GPIO_8_2_pmx_func: GPIO_8_2_pmx_func {
-                     pinctrl-single,pins = <0x8    0x0>;
-		};
-		GPIO_8_2_pmx_idle: GPIO_8_2_pmx_idle {
-                     pinctrl-single,pins = <0x8    0x1>;
-		};
-
-		SD_CLK_pmx_func: SD_CLK_pmx_func {
-                     pinctrl-single,pins = <0xC    0x0>;
-		};
-		SD_CLK_pmx_idle: SD_CLK_pmx_idle {
-                     pinctrl-single,pins = <0xC    0x1>;
-		};
-
-		SD_CMD_pmx_func: SD_CMD_pmx_func {
-                     pinctrl-single,pins = <0x10    0x0>;
-		};
-		SD_CMD_pmx_idle: SD_CMD_pmx_idle {
-                     pinctrl-single,pins = <0x10    0x1>;
-		};
-
-		SD_DATA0_pmx_func: SD_DATA0_pmx_func {
-                     pinctrl-single,pins = <0x14    0x0>;
-		};
-		SD_DATA0_pmx_idle: SD_DATA0_pmx_idle {
-                     pinctrl-single,pins = <0x14    0x1>;
-		};
-
-		SD_DATA1_pmx_func: SD_DATA1_pmx_func {
-                     pinctrl-single,pins = <0x18    0x0>;
-		};
-		SD_DATA1_pmx_idle: SD_DATA1_pmx_idle {
-                     pinctrl-single,pins = <0x18    0x1>;
-		};
-
-		SD_DATA2_pmx_func: SD_DATA2_pmx_func {
-                     pinctrl-single,pins = <0x1C    0x0>;
-		};
-		SD_DATA2_pmx_idle: SD_DATA2_pmx_idle {
-                     pinctrl-single,pins = <0x1C    0x1>;
-		};
-
-		SD_DATA3_pmx_func: SD_DATA3_pmx_func {
-                     pinctrl-single,pins = <0x20    0x0>;
-		};
-		SD_DATA3_pmx_idle: SD_DATA3_pmx_idle {
-                     pinctrl-single,pins = <0x20    0x1>;
-		};
-
-		ISP_PWDN0_pmx_func: ISP_PWDN0_pmx_func {
-                     pinctrl-single,pins = <0x24    0x0>;
-		};
-		ISP_PWDN0_pmx_idle: ISP_PWDN0_pmx_idle {
-                     pinctrl-single,pins = <0x24    0x0>;
-		};
-
-		ISP_PWDN1_pmx_func: ISP_PWDN1_pmx_func {
-                     pinctrl-single,pins = <0x28    0x0>;
-		};
-		ISP_PWDN1_pmx_idle: ISP_PWDN1_pmx_idle {
-                     pinctrl-single,pins = <0x28    0x0>;
-		};
-
-		ISP_PWDN2_pmx_func: ISP_PWDN2_pmx_func {
-                     pinctrl-single,pins = <0x2C    0x0>;
-		};
-		ISP_PWDN2_pmx_idle: ISP_PWDN2_pmx_idle {
-                     pinctrl-single,pins = <0x2C    0x0>;
-		};
-
-		ISP_SHUTTER0_pmx_func: ISP_SHUTTER0_pmx_func {
-                     pinctrl-single,pins = <0x30    0x1>;
-		};
-		ISP_SHUTTER0_pmx_idle: ISP_SHUTTER0_pmx_idle {
-                     pinctrl-single,pins = <0x30    0x1>;
-		};
-
-		ISP_SHUTTER1_pmx_func: ISP_SHUTTER1_pmx_func {
-                     pinctrl-single,pins = <0x34    0x1>;
-		};
-		ISP_SHUTTER1_pmx_idle: ISP_SHUTTER1_pmx_idle {
-                     pinctrl-single,pins = <0x34    0x1>;
-		};
-
-		ISP_PWM_pmx_func: ISP_PWM_pmx_func {
-                     pinctrl-single,pins = <0x38    0x1>;
-		};
-		ISP_PWM_pmx_idle: ISP_PWM_pmx_idle {
-                     pinctrl-single,pins = <0x38    0x1>;
-		};
-
-		ISP_CCLK0_pmx_func: ISP_CCLK0_pmx_func {
-                     pinctrl-single,pins = <0x3C    0x0>;
-		};
-		ISP_CCLK0_pmx_idle: ISP_CCLK0_pmx_idle {
-                     pinctrl-single,pins = <0x3C    0x0>;
-		};
-
-		ISP_CCLK1_pmx_func: ISP_CCLK1_pmx_func {
-                     pinctrl-single,pins = <0x40    0x0>;
-		};
-		ISP_CCLK1_pmx_idle: ISP_CCLK1_pmx_idle {
-                     pinctrl-single,pins = <0x40    0x0>;
-		};
-
-		ISP_RESETB0_pmx_func: ISP_RESETB0_pmx_func {
-                     pinctrl-single,pins = <0x44    0x0>;
-		};
-		ISP_RESETB0_pmx_idle: ISP_RESETB0_pmx_idle {
-                     pinctrl-single,pins = <0x44    0x0>;
-		};
-
-		ISP_RESETB1_pmx_func: ISP_RESETB1_pmx_func {
-                     pinctrl-single,pins = <0x48    0x0>;
-		};
-		ISP_RESETB1_pmx_idle: ISP_RESETB1_pmx_idle {
-                     pinctrl-single,pins = <0x48    0x0>;
-		};
-
-		ISP_STROBE0_pmx_func: ISP_STROBE0_pmx_func {
-                     pinctrl-single,pins = <0x4C    0x1>;
-		};
-		ISP_STROBE0_pmx_idle: ISP_STROBE0_pmx_idle {
-                     pinctrl-single,pins = <0x4C    0x1>;
-		};
-
-		ISP_STROBE1_pmx_func: ISP_STROBE1_pmx_func {
-                     pinctrl-single,pins = <0x50    0x1>;
-		};
-		ISP_STROBE1_pmx_idle: ISP_STROBE1_pmx_idle {
-                     pinctrl-single,pins = <0x50    0x1>;
-		};
-
-		ISP_SDA0_pmx_func: ISP_SDA0_pmx_func {
-                     pinctrl-single,pins = <0x54    0x0>;
-		};
-		ISP_SDA0_pmx_idle: ISP_SDA0_pmx_idle {
-                     pinctrl-single,pins = <0x54    0x0>;
-		};
-
-		ISP_SCL0_pmx_func: ISP_SCL0_pmx_func {
-                     pinctrl-single,pins = <0x58    0x0>;
-		};
-		ISP_SCL0_pmx_idle: ISP_SCL0_pmx_idle {
-                     pinctrl-single,pins = <0x58    0x0>;
-		};
-
-		ISP_SDA1_pmx_func: ISP_SDA1_pmx_func {
-                     pinctrl-single,pins = <0x5C    0x0>;
-		};
-		ISP_SDA1_pmx_idle: ISP_SDA1_pmx_idle {
-                     pinctrl-single,pins = <0x5C    0x0>;
-		};
-
-		ISP_SCL1_pmx_func: ISP_SCL1_pmx_func {
-                     pinctrl-single,pins = <0x60    0x0>;
-		};
-		ISP_SCL1_pmx_idle: ISP_SCL1_pmx_idle {
-                     pinctrl-single,pins = <0x60    0x0>;
-		};
-
-		GPIO_11_2_pmx_func: GPIO_11_2_pmx_func {
-                     pinctrl-single,pins = <0x64    0x1>;
-		};
-		GPIO_11_2_pmx_idle: GPIO_11_2_pmx_idle {
-                     pinctrl-single,pins = <0x64    0x1>;
-		};
-
-		HKADC_SSI_pmx_func: HKADC_SSI_pmx_func {
-                     pinctrl-single,pins = <0x68    0x0>;
-		};
-		HKADC_SSI_pmx_idle: HKADC_SSI_pmx_idle {
-                     pinctrl-single,pins = <0x68    0x0>;
-		};
-
-		CODEC_CLK_pmx_func: CODEC_CLK_pmx_func {
-                     pinctrl-single,pins = <0x6C    0x0>;
-		};
-		CODEC_CLK_pmx_idle: CODEC_CLK_pmx_idle {
-                     pinctrl-single,pins = <0x6C    0x0>;
-		};
-
-		DMIC_CLK_pmx_func: DMIC_CLK_pmx_func {
-                     pinctrl-single,pins = <0x70    0x1>;
-		};
-		DMIC_CLK_pmx_idle: DMIC_CLK_pmx_idle {
-                     pinctrl-single,pins = <0x70    0x1>;
-		};
-
-		CODEC_SYNC_pmx_func: CODEC_SYNC_pmx_func {
-                     pinctrl-single,pins = <0x74    0x0>;
-		};
-		CODEC_SYNC_pmx_idle: CODEC_SYNC_pmx_idle {
-                     pinctrl-single,pins = <0x74    0x0>;
-		};
-
-		CODEC_DATAIN_pmx_func: CODEC_DATAIN_pmx_func {
-                     pinctrl-single,pins = <0x78    0x0>;
-		};
-		CODEC_DATAIN_pmx_idle: CODEC_DATAIN_pmx_idle {
-                     pinctrl-single,pins = <0x78    0x0>;
-		};
-
-		CODEC_DATAOUT_pmx_func: CODEC_DATAOUT_pmx_func {
-                     pinctrl-single,pins = <0x7C    0x0>;
-		};
-		CODEC_DATAOUT_pmx_idle: CODEC_DATAOUT_pmx_idle {
-                     pinctrl-single,pins = <0x7C    0x0>;
-		};
-
-		FM_XCLK_pmx_func: FM_XCLK_pmx_func {
-                     pinctrl-single,pins = <0x80    0x1>;
-		};
-		FM_XCLK_pmx_idle: FM_XCLK_pmx_idle {
-                     pinctrl-single,pins = <0x80    0x1>;
-		};
-
-		FM_XFS_pmx_func: FM_XFS_pmx_func {
-                     pinctrl-single,pins = <0x84    0x1>;
-		};
-		FM_XFS_pmx_idle: FM_XFS_pmx_idle {
-                     pinctrl-single,pins = <0x84    0x1>;
-		};
-
-		FM_DI_pmx_func: FM_DI_pmx_func {
-                     pinctrl-single,pins = <0x88    0x1>;
-		};
-		FM_DI_pmx_idle: FM_DI_pmx_idle {
-                     pinctrl-single,pins = <0x88    0x1>;
-		};
-
-		FM_DO_pmx_func: FM_DO_pmx_func {
-                     pinctrl-single,pins = <0x8C    0x1>;
-		};
-		FM_DO_pmx_idle: FM_DO_pmx_idle {
-                     pinctrl-single,pins = <0x8C    0x1>;
-		};
-
-		BT_XCLK_pmx_func: BT_XCLK_pmx_func {
-                     pinctrl-single,pins = <0x90    0x0>;
-		};
-		BT_XCLK_pmx_idle: BT_XCLK_pmx_idle {
-                     pinctrl-single,pins = <0x90    0x0>;
-		};
-
-		BT_XFS_pmx_func: BT_XFS_pmx_func {
-                     pinctrl-single,pins = <0x94    0x0>;
-		};
-		BT_XFS_pmx_idle: BT_XFS_pmx_idle {
-                     pinctrl-single,pins = <0x94    0x0>;
-		};
-
-		BT_DI_pmx_func: BT_DI_pmx_func {
-                     pinctrl-single,pins = <0x98    0x0>;
-		};
-		BT_DI_pmx_idle: BT_DI_pmx_idle {
-                     pinctrl-single,pins = <0x98    0x0>;
-		};
-
-		BT_DO_pmx_func: BT_DO_pmx_func {
-                     pinctrl-single,pins = <0x9C    0x0>;
-		};
-		BT_DO_pmx_idle: BT_DO_pmx_idle {
-                     pinctrl-single,pins = <0x9C    0x0>;
-		};
-
-		PWM_IN_pmx_func: PWM_IN_pmx_func {
-                     pinctrl-single,pins = <0xB8    0x1>;
-		};
-		PWM_IN_pmx_idle: PWM_IN_pmx_idle {
-                     pinctrl-single,pins = <0xB8    0x1>;
-		};
-
-		BL_PWM_pmx_func: BL_PWM_pmx_func {
-                     pinctrl-single,pins = <0xBC    0x1>;
-		};
-		BL_PWM_pmx_idle: BL_PWM_pmx_idle {
-                     pinctrl-single,pins = <0xBC    0x1>;
-		};
-
-		UART0_RXD_pmx_func: UART0_RXD_pmx_func {
-                     pinctrl-single,pins = <0xC0    0x0>;
-		};
-		UART0_RXD_pmx_idle: UART0_RXD_pmx_idle {
-                     pinctrl-single,pins = <0xC0    0x0>;
-		};
-
-		UART0_TXD_pmx_func: UART0_TXD_pmx_func {
-                     pinctrl-single,pins = <0xC4    0x0>;
-		};
-		UART0_TXD_pmx_idle: UART0_TXD_pmx_idle {
-                     pinctrl-single,pins = <0xC4    0x0>;
-		};
-
-		UART1_CTS_N_pmx_func: UART1_CTS_N_pmx_func {
-                     pinctrl-single,pins = <0xC8    0x0>;
-		};
-		UART1_CTS_N_pmx_idle: UART1_CTS_N_pmx_idle {
-                     pinctrl-single,pins = <0xC8    0x0>;
-		};
-
-		UART1_RTS_N_pmx_func: UART1_RTS_N_pmx_func {
-                     pinctrl-single,pins = <0xCC    0x0>;
-		};
-		UART1_RTS_N_pmx_idle: UART1_RTS_N_pmx_idle {
-                     pinctrl-single,pins = <0xCC    0x0>;
-		};
-
-		UART1_RXD_pmx_func: UART1_RXD_pmx_func {
-                     pinctrl-single,pins = <0xD0    0x0>;
-		};
-		UART1_RXD_pmx_idle: UART1_RXD_pmx_idle {
-                     pinctrl-single,pins = <0xD0    0x0>;
-		};
-
-		UART1_TXD_pmx_func: UART1_TXD_pmx_func {
-                     pinctrl-single,pins = <0xD4    0x0>;
-		};
-		UART1_TXD_pmx_idle: UART1_TXD_pmx_idle {
-                     pinctrl-single,pins = <0xD4    0x0>;
-		};
-
-		UART2_CTS_N_pmx_func: UART2_CTS_N_pmx_func {
-                     pinctrl-single,pins = <0xD8    0x0>;
-		};
-		UART2_CTS_N_pmx_idle: UART2_CTS_N_pmx_idle {
-                     pinctrl-single,pins = <0xD8    0x0>;
-		};
-
-		UART2_RTS_N_pmx_func: UART2_RTS_N_pmx_func {
-                     pinctrl-single,pins = <0xDC    0x0>;
-		};
-		UART2_RTS_N_pmx_idle: UART2_RTS_N_pmx_idle {
-                     pinctrl-single,pins = <0xDC    0x0>;
-		};
-
-		UART2_RXD_pmx_func: UART2_RXD_pmx_func {
-                     pinctrl-single,pins = <0xE0    0x0>;
-		};
-		UART2_RXD_pmx_idle: UART2_RXD_pmx_idle {
-                     pinctrl-single,pins = <0xE0    0x0>;
-		};
-
-		UART2_TXD_pmx_func: UART2_TXD_pmx_func {
-                     pinctrl-single,pins = <0xE4    0x0>;
-		};
-		UART2_TXD_pmx_idle: UART2_TXD_pmx_idle {
-                     pinctrl-single,pins = <0xE4    0x0>;
-		};
-
-		I2C0_SCL_pmx_func: I2C0_SCL_pmx_func {
-                     pinctrl-single,pins = <0xE8    0x0>;
-		};
-		I2C0_SCL_pmx_idle: I2C0_SCL_pmx_idle {
-                     pinctrl-single,pins = <0xE8    0x0>;
-		};
-
-		I2C0_SDA_pmx_func: I2C0_SDA_pmx_func {
-                     pinctrl-single,pins = <0xEC    0x0>;
-		};
-		I2C0_SDA_pmx_idle: I2C0_SDA_pmx_idle {
-                     pinctrl-single,pins = <0xEC    0x0>;
-		};
-
-		I2C1_SCL_pmx_func: I2C1_SCL_pmx_func {
-                     pinctrl-single,pins = <0xF0    0x0>;
-		};
-		I2C1_SCL_pmx_idle: I2C1_SCL_pmx_idle {
-                     pinctrl-single,pins = <0xF0    0x0>;
-		};
-
-		I2C1_SDA_pmx_func: I2C1_SDA_pmx_func {
-                     pinctrl-single,pins = <0xF4    0x0>;
-		};
-		I2C1_SDA_pmx_idle: I2C1_SDA_pmx_idle {
-                     pinctrl-single,pins = <0xF4    0x0>;
-		};
-
-		I2C2_SCL_pmx_func: I2C2_SCL_pmx_func {
-                     pinctrl-single,pins = <0xF8    0x0>;
-		};
-		I2C2_SCL_pmx_idle: I2C2_SCL_pmx_idle {
-                     pinctrl-single,pins = <0xF8    0x0>;
-		};
-
-		I2C2_SDA_pmx_func: I2C2_SDA_pmx_func {
-                     pinctrl-single,pins = <0xFC    0x0>;
-		};
-		I2C2_SDA_pmx_idle: I2C2_SDA_pmx_idle {
-                     pinctrl-single,pins = <0xFC    0x0>;
-		};
-
-		EMMC_CLK_pmx_func: EMMC_CLK_pmx_func {
-                     pinctrl-single,pins = <0x100    0x0>;
-		};
-		EMMC_CLK_pmx_idle: EMMC_CLK_pmx_idle {
-                     pinctrl-single,pins = <0x100    0x0>;
-		};
-
-		EMMC_CMD_pmx_func: EMMC_CMD_pmx_func {
-                     pinctrl-single,pins = <0x104    0x0>;
-		};
-		EMMC_CMD_pmx_idle: EMMC_CMD_pmx_idle {
-                     pinctrl-single,pins = <0x104    0x0>;
-		};
-
-		EMMC_DATA0_pmx_func: EMMC_DATA0_pmx_func {
-                     pinctrl-single,pins = <0x108    0x0>;
-		};
-		EMMC_DATA0_pmx_idle: EMMC_DATA0_pmx_idle {
-                     pinctrl-single,pins = <0x108    0x0>;
-		};
-
-		EMMC_DATA1_pmx_func: EMMC_DATA1_pmx_func {
-                     pinctrl-single,pins = <0x10C    0x0>;
-		};
-		EMMC_DATA1_pmx_idle: EMMC_DATA1_pmx_idle {
-                     pinctrl-single,pins = <0x10C    0x0>;
-		};
-
-		EMMC_DATA2_pmx_func: EMMC_DATA2_pmx_func {
-                     pinctrl-single,pins = <0x110    0x0>;
-		};
-		EMMC_DATA2_pmx_idle: EMMC_DATA2_pmx_idle {
-                     pinctrl-single,pins = <0x110    0x0>;
-		};
-
-		EMMC_DATA3_pmx_func: EMMC_DATA3_pmx_func {
-                     pinctrl-single,pins = <0x114    0x0>;
-		};
-		EMMC_DATA3_pmx_idle: EMMC_DATA3_pmx_idle {
-                     pinctrl-single,pins = <0x114    0x0>;
-		};
-
-		EMMC_DATA4_pmx_func: EMMC_DATA4_pmx_func {
-                     pinctrl-single,pins = <0x118    0x0>;
-		};
-		EMMC_DATA4_pmx_idle: EMMC_DATA4_pmx_idle {
-                     pinctrl-single,pins = <0x118    0x0>;
-		};
-
-		EMMC_DATA5_pmx_func: EMMC_DATA5_pmx_func {
-                     pinctrl-single,pins = <0x11C    0x0>;
-		};
-		EMMC_DATA5_pmx_idle: EMMC_DATA5_pmx_idle {
-                     pinctrl-single,pins = <0x11C    0x0>;
-		};
-
-		EMMC_DATA6_pmx_func: EMMC_DATA6_pmx_func {
-                     pinctrl-single,pins = <0x120    0x0>;
-		};
-		EMMC_DATA6_pmx_idle: EMMC_DATA6_pmx_idle {
-                     pinctrl-single,pins = <0x120    0x0>;
-		};
-
-		EMMC_DATA7_pmx_func: EMMC_DATA7_pmx_func {
-                     pinctrl-single,pins = <0x124    0x0>;
-		};
-		EMMC_DATA7_pmx_idle: EMMC_DATA7_pmx_idle {
-                     pinctrl-single,pins = <0x124    0x0>;
-		};
-
-		SDIO_CLK_pmx_func: SDIO_CLK_pmx_func {
-                     pinctrl-single,pins = <0x128    0x0>;
-		};
-		SDIO_CLK_pmx_idle: SDIO_CLK_pmx_idle {
-                     pinctrl-single,pins = <0x128    0x1>;
-		};
-
-		SDIO_CMD_pmx_func: SDIO_CMD_pmx_func {
-                     pinctrl-single,pins = <0x12C    0x0>;
-		};
-		SDIO_CMD_pmx_idle: SDIO_CMD_pmx_idle {
-                     pinctrl-single,pins = <0x12C    0x1>;
-		};
-
-		SDIO_DATA0_pmx_func: SDIO_DATA0_pmx_func {
-                     pinctrl-single,pins = <0x130    0x0>;
-		};
-		SDIO_DATA0_pmx_idle: SDIO_DATA0_pmx_idle {
-                     pinctrl-single,pins = <0x130    0x1>;
-		};
-
-		SDIO_DATA1_pmx_func: SDIO_DATA1_pmx_func {
-                     pinctrl-single,pins = <0x134    0x0>;
-		};
-		SDIO_DATA1_pmx_idle: SDIO_DATA1_pmx_idle {
-                     pinctrl-single,pins = <0x134    0x1>;
-		};
-
-		SDIO_DATA2_pmx_func: SDIO_DATA2_pmx_func {
-                     pinctrl-single,pins = <0x138    0x0>;
-		};
-		SDIO_DATA2_pmx_idle: SDIO_DATA2_pmx_idle {
-                     pinctrl-single,pins = <0x138    0x1>;
-		};
-
-		SDIO_DATA3_pmx_func: SDIO_DATA3_pmx_func {
-                     pinctrl-single,pins = <0x13C    0x0>;
-		};
-		SDIO_DATA3_pmx_idle: SDIO_DATA3_pmx_idle {
-                     pinctrl-single,pins = <0x13C    0x1>;
-		};
-
-		GPIO_3_0_pmx_func: GPIO_3_0_pmx_func {
-                     pinctrl-single,pins = <0x140    0x0>;
-		};
-		GPIO_3_0_pmx_idle: GPIO_3_0_pmx_idle {
-                     pinctrl-single,pins = <0x140    0x0>;
-		};
-
-		GPIO_3_1_pmx_func: GPIO_3_1_pmx_func {
-                     pinctrl-single,pins = <0x144    0x0>;
-		};
-		GPIO_3_1_pmx_idle: GPIO_3_1_pmx_idle {
-                     pinctrl-single,pins = <0x144    0x0>;
-		};
-
-		GPIO_3_2_pmx_func: GPIO_3_2_pmx_func {
-                     pinctrl-single,pins = <0x148    0x0>;
-		};
-		GPIO_3_2_pmx_idle: GPIO_3_2_pmx_idle {
-                     pinctrl-single,pins = <0x148    0x0>;
-		};
-
-		GPIO_3_3_pmx_func: GPIO_3_3_pmx_func {
-                     pinctrl-single,pins = <0x14C    0x0>;
-		};
-		GPIO_3_3_pmx_idle: GPIO_3_3_pmx_idle {
-                     pinctrl-single,pins = <0x14C    0x0>;
-		};
-
-		AUX_SSI0_pmx_func: AUX_SSI0_pmx_func {
-                     pinctrl-single,pins = <0x150    0x1>;
-		};
-		AUX_SSI0_pmx_idle: AUX_SSI0_pmx_idle {
-                     pinctrl-single,pins = <0x150    0x1>;
-		};
-
-		GPIO_3_5_pmx_func: GPIO_3_5_pmx_func {
-                     pinctrl-single,pins = <0x154    0x0>;
-		};
-		GPIO_3_5_pmx_idle: GPIO_3_5_pmx_idle {
-                     pinctrl-single,pins = <0x154    0x0>;
-		};
-
-		GPIO_3_6_pmx_func: GPIO_3_6_pmx_func {
-                     pinctrl-single,pins = <0x158    0x0>;
-		};
-		GPIO_3_6_pmx_idle: GPIO_3_6_pmx_idle {
-                     pinctrl-single,pins = <0x158    0x0>;
-		};
-
-		GPIO_3_7_pmx_func: GPIO_3_7_pmx_func {
-                     pinctrl-single,pins = <0x15C    0x0>;
-		};
-		GPIO_3_7_pmx_idle: GPIO_3_7_pmx_idle {
-                     pinctrl-single,pins = <0x15C    0x0>;
-		};
-
-		GPIO_4_0_pmx_func: GPIO_4_0_pmx_func {
-                     pinctrl-single,pins = <0x160    0x0>;
-		};
-		GPIO_4_0_pmx_idle: GPIO_4_0_pmx_idle {
-                     pinctrl-single,pins = <0x160    0x0>;
-		};
-
-		GPIO_4_1_pmx_func: GPIO_4_1_pmx_func {
-                     pinctrl-single,pins = <0x164    0x0>;
-		};
-		GPIO_4_1_pmx_idle: GPIO_4_1_pmx_idle {
-                     pinctrl-single,pins = <0x164    0x0>;
-		};
-
-		GPIO_4_2_pmx_func: GPIO_4_2_pmx_func {
-                     pinctrl-single,pins = <0x168    0x0>;
-		};
-		GPIO_4_2_pmx_idle: GPIO_4_2_pmx_idle {
-                     pinctrl-single,pins = <0x168    0x0>;
-		};
-
-		GPIO_4_3_pmx_func: GPIO_4_3_pmx_func {
-                     pinctrl-single,pins = <0x16C    0x0>;
-		};
-		GPIO_4_3_pmx_idle: GPIO_4_3_pmx_idle {
-                     pinctrl-single,pins = <0x16C    0x0>;
-		};
-
-		GPIO_4_4_pmx_func: GPIO_4_4_pmx_func {
-                     pinctrl-single,pins = <0x170    0x1>;
-		};
-		GPIO_4_4_pmx_idle: GPIO_4_4_pmx_idle {
-                     pinctrl-single,pins = <0x170    0x1>;
-		};
-
-		GPIO_4_5_pmx_func: GPIO_4_5_pmx_func {
-                     pinctrl-single,pins = <0x174    0x1>;
-		};
-		GPIO_4_5_pmx_idle: GPIO_4_5_pmx_idle {
-                     pinctrl-single,pins = <0x174    0x1>;
-		};
-
-		GPIO_4_6_pmx_func: GPIO_4_6_pmx_func {
-                     pinctrl-single,pins = <0x178    0x1>;
-		};
-		GPIO_4_6_pmx_idle: GPIO_4_6_pmx_idle {
-                     pinctrl-single,pins = <0x178    0x1>;
-		};
-
-		GPIO_4_7_pmx_func: GPIO_4_7_pmx_func {
-                     pinctrl-single,pins = <0x17C    0x0>;
-		};
-		GPIO_4_7_pmx_idle: GPIO_4_7_pmx_idle {
-                     pinctrl-single,pins = <0x17C    0x0>;
-		};
-
-		GPIO_5_0_pmx_func: GPIO_5_0_pmx_func {
-                     pinctrl-single,pins = <0x180    0x0>;
-		};
-		GPIO_5_0_pmx_idle: GPIO_5_0_pmx_idle {
-                     pinctrl-single,pins = <0x180    0x0>;
-		};
-
-		GPIO_5_1_pmx_func: GPIO_5_1_pmx_func {
-                     pinctrl-single,pins = <0x184    0x0>;
-		};
-		GPIO_5_1_pmx_idle: GPIO_5_1_pmx_idle {
-                     pinctrl-single,pins = <0x184    0x0>;
-		};
-
-		GPIO_5_2_pmx_func: GPIO_5_2_pmx_func {
-                     pinctrl-single,pins = <0x188    0x0>;
-		};
-		GPIO_5_2_pmx_idle: GPIO_5_2_pmx_idle {
-                     pinctrl-single,pins = <0x188    0x0>;
-		};
-
-		GPIO_5_3_pmx_func: GPIO_5_3_pmx_func {
-                     pinctrl-single,pins = <0x18C    0x0>;
-		};
-		GPIO_5_3_pmx_idle: GPIO_5_3_pmx_idle {
-                     pinctrl-single,pins = <0x18C    0x0>;
-		};
-
-		GPIO_5_4_pmx_func: GPIO_5_4_pmx_func {
-                     pinctrl-single,pins = <0x190    0x3>;
-		};
-		GPIO_5_4_pmx_idle: GPIO_5_4_pmx_idle {
-                     pinctrl-single,pins = <0x190    0x3>;
-		};
-
-		GPIO_5_5_pmx_func: GPIO_5_5_pmx_func {
-                     pinctrl-single,pins = <0x194    0x0>;
-		};
-		GPIO_5_5_pmx_idle: GPIO_5_5_pmx_idle {
-                     pinctrl-single,pins = <0x194    0x0>;
-		};
-
-		GPIO_5_6_pmx_func: GPIO_5_6_pmx_func {
-                     pinctrl-single,pins = <0x198    0x0>;
-		};
-		GPIO_5_6_pmx_idle: GPIO_5_6_pmx_idle {
-                     pinctrl-single,pins = <0x198    0x0>;
-		};
-
-		GPIO_5_7_pmx_func: GPIO_5_7_pmx_func {
-                     pinctrl-single,pins = <0x19C    0x0>;
-		};
-		GPIO_5_7_pmx_idle: GPIO_5_7_pmx_idle {
-                     pinctrl-single,pins = <0x19C    0x0>;
-		};
-
-		GPIO_6_0_pmx_func: GPIO_6_0_pmx_func {
-                     pinctrl-single,pins = <0x1A0    0x0>;
-		};
-		GPIO_6_0_pmx_idle: GPIO_6_0_pmx_idle {
-                     pinctrl-single,pins = <0x1A0    0x0>;
-		};
-
-		GPIO_6_1_pmx_func: GPIO_6_1_pmx_func {
-                     pinctrl-single,pins = <0x1A4    0x0>;
-		};
-		GPIO_6_1_pmx_idle: GPIO_6_1_pmx_idle {
-                     pinctrl-single,pins = <0x1A4    0x0>;
-		};
-
-		GPIO_6_2_pmx_func: GPIO_6_2_pmx_func {
-                     pinctrl-single,pins = <0x1A8    0x0>;
-		};
-		GPIO_6_2_pmx_idle: GPIO_6_2_pmx_idle {
-                     pinctrl-single,pins = <0x1A8    0x0>;
-		};
-
-		GPIO_6_3_pmx_func: GPIO_6_3_pmx_func {
-                     pinctrl-single,pins = <0x1AC    0x0>;
-		};
-		GPIO_6_3_pmx_idle: GPIO_6_3_pmx_idle {
-                     pinctrl-single,pins = <0x1AC    0x0>;
-		};
-
-		GPIO_6_4_pmx_func: GPIO_6_4_pmx_func {
-                     pinctrl-single,pins = <0x1B0    0x3>;
-		};
-		GPIO_6_4_pmx_idle: GPIO_6_4_pmx_idle {
-                     pinctrl-single,pins = <0x1B0    0x3>;
-		};
-
-		GPIO_6_5_pmx_func: GPIO_6_5_pmx_func {
-                     pinctrl-single,pins = <0x1B4    0x1>;
-		};
-		GPIO_6_5_pmx_idle: GPIO_6_5_pmx_idle {
-                     pinctrl-single,pins = <0x1B4    0x1>;
-		};
-
-		GPIO_6_6_pmx_func: GPIO_6_6_pmx_func {
-                     pinctrl-single,pins = <0x1B8    0x0>;
-		};
-		GPIO_6_6_pmx_idle: GPIO_6_6_pmx_idle {
-                     pinctrl-single,pins = <0x1B8    0x0>;
-		};
-
-		GPIO_6_7_pmx_func: GPIO_6_7_pmx_func {
-                     pinctrl-single,pins = <0x1BC    0x0>;
-		};
-		GPIO_6_7_pmx_idle: GPIO_6_7_pmx_idle {
-                     pinctrl-single,pins = <0x1BC    0x0>;
-		};
-
-		GPIO_7_0_pmx_func: GPIO_7_0_pmx_func {
-                     pinctrl-single,pins = <0x1C0    0x0>;
-		};
-		GPIO_7_0_pmx_idle: GPIO_7_0_pmx_idle {
-                     pinctrl-single,pins = <0x1C0    0x0>;
-		};
-
-		GPIO_7_1_pmx_func: GPIO_7_1_pmx_func {
-                     pinctrl-single,pins = <0x1C4    0x0>;
-		};
-		GPIO_7_1_pmx_idle: GPIO_7_1_pmx_idle {
-                     pinctrl-single,pins = <0x1C4    0x0>;
-		};
-
-		GPIO_7_4_pmx_func: GPIO_7_4_pmx_func {
-                     pinctrl-single,pins = <0x1D0    0x0>;
-		};
-		GPIO_7_4_pmx_idle: GPIO_7_4_pmx_idle {
-                     pinctrl-single,pins = <0x1D0    0x0>;
-		};
-
-		GPIO_7_5_pmx_func: GPIO_7_5_pmx_func {
-                     pinctrl-single,pins = <0x1D4    0x0>;
-		};
-		GPIO_7_5_pmx_idle: GPIO_7_5_pmx_idle {
-                     pinctrl-single,pins = <0x1D4    0x0>;
-		};
-
-		GPIO_7_6_pmx_func: GPIO_7_6_pmx_func {
-                     pinctrl-single,pins = <0x1D8    0x1>;
-		};
-		GPIO_7_6_pmx_idle: GPIO_7_6_pmx_idle {
-                     pinctrl-single,pins = <0x1D8    0x1>;
-		};
-
-		GPIO_7_7_pmx_func: GPIO_7_7_pmx_func {
-                     pinctrl-single,pins = <0x1DC    0x1>;
-		};
-		GPIO_7_7_pmx_idle: GPIO_7_7_pmx_idle {
-                     pinctrl-single,pins = <0x1DC    0x1>;
-		};
-
-		GPIO_8_0_pmx_func: GPIO_8_0_pmx_func {
-                     pinctrl-single,pins = <0x1E0    0x0>;
-		};
-		GPIO_8_0_pmx_idle: GPIO_8_0_pmx_idle {
-                     pinctrl-single,pins = <0x1E0    0x0>;
-		};
-
-		GPIO_8_1_pmx_func: GPIO_8_1_pmx_func {
-                     pinctrl-single,pins = <0x1E4    0x0>;
-		};
-		GPIO_8_1_pmx_idle: GPIO_8_1_pmx_idle {
-                     pinctrl-single,pins = <0x1E4    0x0>;
-		};
-
-       };
-
-    pmx1: pinmux@f7010800 {
-		BOOT_SEL_cfg_func: BOOT_SEL_cfg_func {
-                     pinctrl-single,pins = <0x0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		BOOT_SEL_cfg_idle: BOOT_SEL_cfg_idle {
-                     pinctrl-single,pins = <0x0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		PMU_SSI_cfg_func: PMU_SSI_cfg_func {
-                     pinctrl-single,pins = <0x4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		PMU_SSI_cfg_idle: PMU_SSI_cfg_idle {
-                     pinctrl-single,pins = <0x4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_8_2_cfg_func: GPIO_8_2_cfg_func {
-                     pinctrl-single,pins = <0x8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_8_2_cfg_idle: GPIO_8_2_cfg_idle {
-                     pinctrl-single,pins = <0x8  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SD_CLK_cfg_func: SD_CLK_cfg_func {
-                     pinctrl-single,pins = <0xC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x30 0x70>;
-		};
-		SD_CLK_cfg_idle: SD_CLK_cfg_idle {
-                     pinctrl-single,pins = <0xC  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SD_CMD_cfg_func: SD_CMD_cfg_func {
-                     pinctrl-single,pins = <0x10  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x20 0x70>;
-		};
-		SD_CMD_cfg_idle: SD_CMD_cfg_idle {
-                     pinctrl-single,pins = <0x10  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SD_DATA0_cfg_func: SD_DATA0_cfg_func {
-                     pinctrl-single,pins = <0x14  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x20 0x70>;
-		};
-		SD_DATA0_cfg_idle: SD_DATA0_cfg_idle {
-                     pinctrl-single,pins = <0x14  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SD_DATA1_cfg_func: SD_DATA1_cfg_func {
-                     pinctrl-single,pins = <0x18  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x20 0x70>;
-		};
-		SD_DATA1_cfg_idle: SD_DATA1_cfg_idle {
-                     pinctrl-single,pins = <0x18  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SD_DATA2_cfg_func: SD_DATA2_cfg_func {
-                     pinctrl-single,pins = <0x1C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x20 0x70>;
-		};
-		SD_DATA2_cfg_idle: SD_DATA2_cfg_idle {
-                     pinctrl-single,pins = <0x1C  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SD_DATA3_cfg_func: SD_DATA3_cfg_func {
-                     pinctrl-single,pins = <0x20  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x20 0x70>;
-		};
-		SD_DATA3_cfg_idle: SD_DATA3_cfg_idle {
-                     pinctrl-single,pins = <0x20  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_PWDN0_cfg_func: ISP_PWDN0_cfg_func {
-                     pinctrl-single,pins = <0x28  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_PWDN0_cfg_idle: ISP_PWDN0_cfg_idle {
-                     pinctrl-single,pins = <0x28  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_PWDN1_cfg_func: ISP_PWDN1_cfg_func {
-                     pinctrl-single,pins = <0x2C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_PWDN1_cfg_idle: ISP_PWDN1_cfg_idle {
-                     pinctrl-single,pins = <0x2C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_PWDN2_cfg_func: ISP_PWDN2_cfg_func {
-                     pinctrl-single,pins = <0x30  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_PWDN2_cfg_idle: ISP_PWDN2_cfg_idle {
-                     pinctrl-single,pins = <0x30  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_SHUTTER0_cfg_func: ISP_SHUTTER0_cfg_func {
-                     pinctrl-single,pins = <0x34  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_SHUTTER0_cfg_idle: ISP_SHUTTER0_cfg_idle {
-                     pinctrl-single,pins = <0x34  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_SHUTTER1_cfg_func: ISP_SHUTTER1_cfg_func {
-                     pinctrl-single,pins = <0x38  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_SHUTTER1_cfg_idle: ISP_SHUTTER1_cfg_idle {
-                     pinctrl-single,pins = <0x38  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_PWM_cfg_func: ISP_PWM_cfg_func {
-                     pinctrl-single,pins = <0x3C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_PWM_cfg_idle: ISP_PWM_cfg_idle {
-                     pinctrl-single,pins = <0x3C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_CCLK0_cfg_func: ISP_CCLK0_cfg_func {
-                     pinctrl-single,pins = <0x40  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_CCLK0_cfg_idle: ISP_CCLK0_cfg_idle {
-                     pinctrl-single,pins = <0x40  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_CCLK1_cfg_func: ISP_CCLK1_cfg_func {
-                     pinctrl-single,pins = <0x44  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_CCLK1_cfg_idle: ISP_CCLK1_cfg_idle {
-                     pinctrl-single,pins = <0x44  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_RESETB0_cfg_func: ISP_RESETB0_cfg_func {
-                     pinctrl-single,pins = <0x48  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_RESETB0_cfg_idle: ISP_RESETB0_cfg_idle {
-                     pinctrl-single,pins = <0x48  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_RESETB1_cfg_func: ISP_RESETB1_cfg_func {
-                     pinctrl-single,pins = <0x4C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_RESETB1_cfg_idle: ISP_RESETB1_cfg_idle {
-                     pinctrl-single,pins = <0x4C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_STROBE0_cfg_func: ISP_STROBE0_cfg_func {
-                     pinctrl-single,pins = <0x50  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_STROBE0_cfg_idle: ISP_STROBE0_cfg_idle {
-                     pinctrl-single,pins = <0x50  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_STROBE1_cfg_func: ISP_STROBE1_cfg_func {
-                     pinctrl-single,pins = <0x54  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_STROBE1_cfg_idle: ISP_STROBE1_cfg_idle {
-                     pinctrl-single,pins = <0x54  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_SDA0_cfg_func: ISP_SDA0_cfg_func {
-                     pinctrl-single,pins = <0x58  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_SDA0_cfg_idle: ISP_SDA0_cfg_idle {
-                     pinctrl-single,pins = <0x58  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_SCL0_cfg_func: ISP_SCL0_cfg_func {
-                     pinctrl-single,pins = <0x5C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_SCL0_cfg_idle: ISP_SCL0_cfg_idle {
-                     pinctrl-single,pins = <0x5C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_SDA1_cfg_func: ISP_SDA1_cfg_func {
-                     pinctrl-single,pins = <0x60  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_SDA1_cfg_idle: ISP_SDA1_cfg_idle {
-                     pinctrl-single,pins = <0x60  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		ISP_SCL1_cfg_func: ISP_SCL1_cfg_func {
-                     pinctrl-single,pins = <0x64  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		ISP_SCL1_cfg_idle: ISP_SCL1_cfg_idle {
-                     pinctrl-single,pins = <0x64  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_11_2_cfg_func: GPIO_11_2_cfg_func {
-                     pinctrl-single,pins = <0x68  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_11_2_cfg_idle: GPIO_11_2_cfg_idle {
-                     pinctrl-single,pins = <0x68  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		HKADC_SSI_cfg_func: HKADC_SSI_cfg_func {
-                     pinctrl-single,pins = <0x6C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		HKADC_SSI_cfg_idle: HKADC_SSI_cfg_idle {
-                     pinctrl-single,pins = <0x6C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		CODEC_CLK_cfg_func: CODEC_CLK_cfg_func {
-                     pinctrl-single,pins = <0x70  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		CODEC_CLK_cfg_idle: CODEC_CLK_cfg_idle {
-                     pinctrl-single,pins = <0x70  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		DMIC_CLK_cfg_func: DMIC_CLK_cfg_func {
-                     pinctrl-single,pins = <0x74  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		DMIC_CLK_cfg_idle: DMIC_CLK_cfg_idle {
-                     pinctrl-single,pins = <0x74  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		CODEC_SYNC_cfg_func: CODEC_SYNC_cfg_func {
-                     pinctrl-single,pins = <0x78  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		CODEC_SYNC_cfg_idle: CODEC_SYNC_cfg_idle {
-                     pinctrl-single,pins = <0x78  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		CODEC_DATAIN_cfg_func: CODEC_DATAIN_cfg_func {
-                     pinctrl-single,pins = <0x7C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		CODEC_DATAIN_cfg_idle: CODEC_DATAIN_cfg_idle {
-                     pinctrl-single,pins = <0x7C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		CODEC_DATAOUT_cfg_func: CODEC_DATAOUT_cfg_func {
-                     pinctrl-single,pins = <0x80  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		CODEC_DATAOUT_cfg_idle: CODEC_DATAOUT_cfg_idle {
-                     pinctrl-single,pins = <0x80  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		FM_XCLK_cfg_func: FM_XCLK_cfg_func {
-                     pinctrl-single,pins = <0x84  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		FM_XCLK_cfg_idle: FM_XCLK_cfg_idle {
-                     pinctrl-single,pins = <0x84  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		FM_XFS_cfg_func: FM_XFS_cfg_func {
-                     pinctrl-single,pins = <0x88  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		FM_XFS_cfg_idle: FM_XFS_cfg_idle {
-                     pinctrl-single,pins = <0x88  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		FM_DI_cfg_func: FM_DI_cfg_func {
-                     pinctrl-single,pins = <0x8C  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		FM_DI_cfg_idle: FM_DI_cfg_idle {
-                     pinctrl-single,pins = <0x8C  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		FM_DO_cfg_func: FM_DO_cfg_func {
-                     pinctrl-single,pins = <0x90  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		FM_DO_cfg_idle: FM_DO_cfg_idle {
-                     pinctrl-single,pins = <0x90  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		BT_XCLK_cfg_func: BT_XCLK_cfg_func {
-                     pinctrl-single,pins = <0x94  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		BT_XCLK_cfg_idle: BT_XCLK_cfg_idle {
-                     pinctrl-single,pins = <0x94  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		BT_XFS_cfg_func: BT_XFS_cfg_func {
-                     pinctrl-single,pins = <0x98  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		BT_XFS_cfg_idle: BT_XFS_cfg_idle {
-                     pinctrl-single,pins = <0x98  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		BT_DI_cfg_func: BT_DI_cfg_func {
-                     pinctrl-single,pins = <0x9C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		BT_DI_cfg_idle: BT_DI_cfg_idle {
-                     pinctrl-single,pins = <0x9C  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		BT_DO_cfg_func: BT_DO_cfg_func {
-                     pinctrl-single,pins = <0xA0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		BT_DO_cfg_idle: BT_DO_cfg_idle {
-                     pinctrl-single,pins = <0xA0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		PWM_IN_cfg_func: PWM_IN_cfg_func {
-                     pinctrl-single,pins = <0xBC  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		PWM_IN_cfg_idle: PWM_IN_cfg_idle {
-                     pinctrl-single,pins = <0xBC  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		BL_PWM_cfg_func: BL_PWM_cfg_func {
-                     pinctrl-single,pins = <0xC0  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		BL_PWM_cfg_idle: BL_PWM_cfg_idle {
-                     pinctrl-single,pins = <0xC0  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		UART0_RXD_cfg_func: UART0_RXD_cfg_func {
-                     pinctrl-single,pins = <0xC4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		UART0_RXD_cfg_idle: UART0_RXD_cfg_idle {
-                     pinctrl-single,pins = <0xC4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		UART0_TXD_cfg_func: UART0_TXD_cfg_func {
-                     pinctrl-single,pins = <0xC8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		UART0_TXD_cfg_idle: UART0_TXD_cfg_idle {
-                     pinctrl-single,pins = <0xC8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-
-		UART1_CTS_N_cfg_func: UART1_CTS_N_cfg_func {
-                     pinctrl-single,pins = <0xCC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		UART1_CTS_N_cfg_idle: UART1_CTS_N_cfg_idle {
-                     pinctrl-single,pins = <0xCC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		UART1_RTS_N_cfg_func: UART1_RTS_N_cfg_func {
-                     pinctrl-single,pins = <0xD0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		UART1_RTS_N_cfg_idle: UART1_RTS_N_cfg_idle {
-                     pinctrl-single,pins = <0xD0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		UART1_RXD_cfg_func: UART1_RXD_cfg_func {
-                     pinctrl-single,pins = <0xD4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		UART1_RXD_cfg_idle: UART1_RXD_cfg_idle {
-                     pinctrl-single,pins = <0xD4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		UART1_TXD_cfg_func: UART1_TXD_cfg_func {
-                     pinctrl-single,pins = <0xD8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		UART1_TXD_cfg_idle: UART1_TXD_cfg_idle {
-                     pinctrl-single,pins = <0xD8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		UART2_CTS_N_cfg_func: UART2_CTS_N_cfg_func {
-                     pinctrl-single,pins = <0xDC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		UART2_CTS_N_cfg_idle: UART2_CTS_N_cfg_idle {
-                     pinctrl-single,pins = <0xDC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		UART2_RTS_N_cfg_func: UART2_RTS_N_cfg_func {
-                     pinctrl-single,pins = <0xE0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		UART2_RTS_N_cfg_idle: UART2_RTS_N_cfg_idle {
-                     pinctrl-single,pins = <0xE0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		UART2_RXD_cfg_func: UART2_RXD_cfg_func {
-                     pinctrl-single,pins = <0xE4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		UART2_RXD_cfg_idle: UART2_RXD_cfg_idle {
-                     pinctrl-single,pins = <0xE4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		UART2_TXD_cfg_func: UART2_TXD_cfg_func {
-                     pinctrl-single,pins = <0xE8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		UART2_TXD_cfg_idle: UART2_TXD_cfg_idle {
-                     pinctrl-single,pins = <0xE8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		I2C0_SCL_cfg_func: I2C0_SCL_cfg_func {
-                     pinctrl-single,pins = <0xEC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		I2C0_SCL_cfg_idle: I2C0_SCL_cfg_idle {
-                     pinctrl-single,pins = <0xEC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		I2C0_SDA_cfg_func: I2C0_SDA_cfg_func {
-                     pinctrl-single,pins = <0xF0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		I2C0_SDA_cfg_idle: I2C0_SDA_cfg_idle {
-                     pinctrl-single,pins = <0xF0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		I2C1_SCL_cfg_func: I2C1_SCL_cfg_func {
-                     pinctrl-single,pins = <0xF4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		I2C1_SCL_cfg_idle: I2C1_SCL_cfg_idle {
-                     pinctrl-single,pins = <0xF4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		I2C1_SDA_cfg_func: I2C1_SDA_cfg_func {
-                     pinctrl-single,pins = <0xF8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		I2C1_SDA_cfg_idle: I2C1_SDA_cfg_idle {
-                     pinctrl-single,pins = <0xF8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		I2C2_SCL_cfg_func: I2C2_SCL_cfg_func {
-                     pinctrl-single,pins = <0xFC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		I2C2_SCL_cfg_idle: I2C2_SCL_cfg_idle {
-                     pinctrl-single,pins = <0xFC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		I2C2_SDA_cfg_func: I2C2_SDA_cfg_func {
-                     pinctrl-single,pins = <0x100  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		I2C2_SDA_cfg_idle: I2C2_SDA_cfg_idle {
-                     pinctrl-single,pins = <0x100  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		EMMC_CLK_cfg_func: EMMC_CLK_cfg_func {
-                     pinctrl-single,pins = <0x104  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x20 0x70>;
-		};
-		EMMC_CLK_cfg_idle: EMMC_CLK_cfg_idle {
-                     pinctrl-single,pins = <0x104  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x20 0x70>;
-		};
-
-		EMMC_CMD_cfg_func: EMMC_CMD_cfg_func {
-                     pinctrl-single,pins = <0x108  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		EMMC_CMD_cfg_idle: EMMC_CMD_cfg_idle {
-                     pinctrl-single,pins = <0x108  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-
-		EMMC_DATA0_cfg_func: EMMC_DATA0_cfg_func {
-                     pinctrl-single,pins = <0x10C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		EMMC_DATA0_cfg_idle: EMMC_DATA0_cfg_idle {
-                     pinctrl-single,pins = <0x10C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-
-		EMMC_DATA1_cfg_func: EMMC_DATA1_cfg_func {
-                     pinctrl-single,pins = <0x110  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		EMMC_DATA1_cfg_idle: EMMC_DATA1_cfg_idle {
-                     pinctrl-single,pins = <0x110  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-
-		EMMC_DATA2_cfg_func: EMMC_DATA2_cfg_func {
-                     pinctrl-single,pins = <0x114  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		EMMC_DATA2_cfg_idle: EMMC_DATA2_cfg_idle {
-                     pinctrl-single,pins = <0x114  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-
-		EMMC_DATA3_cfg_func: EMMC_DATA3_cfg_func {
-                     pinctrl-single,pins = <0x118  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		EMMC_DATA3_cfg_idle: EMMC_DATA3_cfg_idle {
-                     pinctrl-single,pins = <0x118  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-
-		EMMC_DATA4_cfg_func: EMMC_DATA4_cfg_func {
-                     pinctrl-single,pins = <0x11C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		EMMC_DATA4_cfg_idle: EMMC_DATA4_cfg_idle {
-                     pinctrl-single,pins = <0x11C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-
-		EMMC_DATA5_cfg_func: EMMC_DATA5_cfg_func {
-                     pinctrl-single,pins = <0x120  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		EMMC_DATA5_cfg_idle: EMMC_DATA5_cfg_idle {
-                     pinctrl-single,pins = <0x120  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-
-		EMMC_DATA6_cfg_func: EMMC_DATA6_cfg_func {
-                     pinctrl-single,pins = <0x124  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		EMMC_DATA6_cfg_idle: EMMC_DATA6_cfg_idle {
-                     pinctrl-single,pins = <0x124  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-
-		EMMC_DATA7_cfg_func: EMMC_DATA7_cfg_func {
-                     pinctrl-single,pins = <0x128  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		EMMC_DATA7_cfg_idle: EMMC_DATA7_cfg_idle {
-                     pinctrl-single,pins = <0x128  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-
-		EMMC_RST_N_cfg_func: EMMC_RST_N_cfg_func {
-                     pinctrl-single,pins = <0x12C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		EMMC_RST_N_cfg_idle: EMMC_RST_N_cfg_idle {
-                     pinctrl-single,pins = <0x12C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-
-		SDIO_CLK_cfg_func: SDIO_CLK_cfg_func {
-                     pinctrl-single,pins = <0x134  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x20 0x70>;
-		};
-		SDIO_CLK_cfg_idle: SDIO_CLK_cfg_idle {
-                     pinctrl-single,pins = <0x134  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SDIO_CMD_cfg_func: SDIO_CMD_cfg_func {
-                     pinctrl-single,pins = <0x138  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		SDIO_CMD_cfg_idle: SDIO_CMD_cfg_idle {
-                     pinctrl-single,pins = <0x138  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SDIO_DATA0_cfg_func: SDIO_DATA0_cfg_func {
-                     pinctrl-single,pins = <0x13C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		SDIO_DATA0_cfg_idle: SDIO_DATA0_cfg_idle {
-                     pinctrl-single,pins = <0x13C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SDIO_DATA1_cfg_func: SDIO_DATA1_cfg_func {
-                     pinctrl-single,pins = <0x140  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		SDIO_DATA1_cfg_idle: SDIO_DATA1_cfg_idle {
-                     pinctrl-single,pins = <0x140  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SDIO_DATA2_cfg_func: SDIO_DATA2_cfg_func {
-                     pinctrl-single,pins = <0x144  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		SDIO_DATA2_cfg_idle: SDIO_DATA2_cfg_idle {
-                     pinctrl-single,pins = <0x144  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SDIO_DATA3_cfg_func: SDIO_DATA3_cfg_func {
-                     pinctrl-single,pins = <0x148  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x10 0x70>;
-		};
-		SDIO_DATA3_cfg_idle: SDIO_DATA3_cfg_idle {
-                     pinctrl-single,pins = <0x148  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_3_0_cfg_func: GPIO_3_0_cfg_func {
-                     pinctrl-single,pins = <0x150  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_3_0_cfg_idle: GPIO_3_0_cfg_idle {
-                     pinctrl-single,pins = <0x150  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_3_1_cfg_func: GPIO_3_1_cfg_func {
-                     pinctrl-single,pins = <0x154  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_3_1_cfg_idle: GPIO_3_1_cfg_idle {
-                     pinctrl-single,pins = <0x154  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_3_2_cfg_func: GPIO_3_2_cfg_func {
-                     pinctrl-single,pins = <0x158  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_3_2_cfg_idle: GPIO_3_2_cfg_idle {
-                     pinctrl-single,pins = <0x158  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_3_3_cfg_func: GPIO_3_3_cfg_func {
-                     pinctrl-single,pins = <0x15C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_3_3_cfg_idle: GPIO_3_3_cfg_idle {
-                     pinctrl-single,pins = <0x15C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		AUX_SSI0_cfg_func: AUX_SSI0_cfg_func {
-                     pinctrl-single,pins = <0x160  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		AUX_SSI0_cfg_idle: AUX_SSI0_cfg_idle {
-                     pinctrl-single,pins = <0x160  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_3_5_cfg_func: GPIO_3_5_cfg_func {
-                     pinctrl-single,pins = <0x164  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_3_5_cfg_idle: GPIO_3_5_cfg_idle {
-                     pinctrl-single,pins = <0x164  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_3_6_cfg_func: GPIO_3_6_cfg_func {
-                     pinctrl-single,pins = <0x168  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_3_6_cfg_idle: GPIO_3_6_cfg_idle {
-                     pinctrl-single,pins = <0x168  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_3_7_cfg_func: GPIO_3_7_cfg_func {
-                     pinctrl-single,pins = <0x16C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_3_7_cfg_idle: GPIO_3_7_cfg_idle {
-                     pinctrl-single,pins = <0x16C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_4_0_cfg_func: GPIO_4_0_cfg_func {
-                     pinctrl-single,pins = <0x170  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_4_0_cfg_idle: GPIO_4_0_cfg_idle {
-                     pinctrl-single,pins = <0x170  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_4_1_cfg_func: GPIO_4_1_cfg_func {
-                     pinctrl-single,pins = <0x174  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_4_1_cfg_idle: GPIO_4_1_cfg_idle {
-                     pinctrl-single,pins = <0x174  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_4_2_cfg_func: GPIO_4_2_cfg_func {
-                     pinctrl-single,pins = <0x178  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_4_2_cfg_idle: GPIO_4_2_cfg_idle {
-                     pinctrl-single,pins = <0x178  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_4_3_cfg_func: GPIO_4_3_cfg_func {
-                     pinctrl-single,pins = <0x17C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_4_3_cfg_idle: GPIO_4_3_cfg_idle {
-                     pinctrl-single,pins = <0x17C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_4_4_cfg_func: GPIO_4_4_cfg_func {
-                     pinctrl-single,pins = <0x180  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_4_4_cfg_idle: GPIO_4_4_cfg_idle {
-                     pinctrl-single,pins = <0x180  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_4_5_cfg_func: GPIO_4_5_cfg_func {
-                     pinctrl-single,pins = <0x184  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_4_5_cfg_idle: GPIO_4_5_cfg_idle {
-                     pinctrl-single,pins = <0x184  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_4_6_cfg_func: GPIO_4_6_cfg_func {
-                     pinctrl-single,pins = <0x188  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_4_6_cfg_idle: GPIO_4_6_cfg_idle {
-                     pinctrl-single,pins = <0x188  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_4_7_cfg_func: GPIO_4_7_cfg_func {
-                     pinctrl-single,pins = <0x18C  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_4_7_cfg_idle: GPIO_4_7_cfg_idle {
-                     pinctrl-single,pins = <0x18C  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_5_0_cfg_func: GPIO_5_0_cfg_func {
-                     pinctrl-single,pins = <0x190  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_5_0_cfg_idle: GPIO_5_0_cfg_idle {
-                     pinctrl-single,pins = <0x190  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_5_1_cfg_func: GPIO_5_1_cfg_func {
-                     pinctrl-single,pins = <0x194  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_5_1_cfg_idle: GPIO_5_1_cfg_idle {
-                     pinctrl-single,pins = <0x194  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_5_2_cfg_func: GPIO_5_2_cfg_func {
-                     pinctrl-single,pins = <0x198  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_5_2_cfg_idle: GPIO_5_2_cfg_idle {
-                     pinctrl-single,pins = <0x198  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_5_3_cfg_func: GPIO_5_3_cfg_func {
-                     pinctrl-single,pins = <0x19C  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_5_3_cfg_idle: GPIO_5_3_cfg_idle {
-                     pinctrl-single,pins = <0x19C  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_5_4_cfg_func: GPIO_5_4_cfg_func {
-                     pinctrl-single,pins = <0x1A0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_5_4_cfg_idle: GPIO_5_4_cfg_idle {
-                     pinctrl-single,pins = <0x1A0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_5_5_cfg_func: GPIO_5_5_cfg_func {
-                     pinctrl-single,pins = <0x1A4  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_5_5_cfg_idle: GPIO_5_5_cfg_idle {
-                     pinctrl-single,pins = <0x1A4  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_5_6_cfg_func: GPIO_5_6_cfg_func {
-                     pinctrl-single,pins = <0x1A8  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_5_6_cfg_idle: GPIO_5_6_cfg_idle {
-                     pinctrl-single,pins = <0x1A8  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_5_7_cfg_func: GPIO_5_7_cfg_func {
-                     pinctrl-single,pins = <0x1AC  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_5_7_cfg_idle: GPIO_5_7_cfg_idle {
-                     pinctrl-single,pins = <0x1AC  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_6_0_cfg_func: GPIO_6_0_cfg_func {
-                     pinctrl-single,pins = <0x1B0  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_6_0_cfg_idle: GPIO_6_0_cfg_idle {
-                     pinctrl-single,pins = <0x1B0  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_6_1_cfg_func: GPIO_6_1_cfg_func {
-                     pinctrl-single,pins = <0x1B4  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_6_1_cfg_idle: GPIO_6_1_cfg_idle {
-                     pinctrl-single,pins = <0x1B4  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_6_2_cfg_func: GPIO_6_2_cfg_func {
-                     pinctrl-single,pins = <0x1B8  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_6_2_cfg_idle: GPIO_6_2_cfg_idle {
-                     pinctrl-single,pins = <0x1B8  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_6_3_cfg_func: GPIO_6_3_cfg_func {
-                     pinctrl-single,pins = <0x1BC  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_6_3_cfg_idle: GPIO_6_3_cfg_idle {
-                     pinctrl-single,pins = <0x1BC  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_6_4_cfg_func: GPIO_6_4_cfg_func {
-                     pinctrl-single,pins = <0x1C0  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_6_4_cfg_idle: GPIO_6_4_cfg_idle {
-                     pinctrl-single,pins = <0x1C0  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_6_5_cfg_func: GPIO_6_5_cfg_func {
-                     pinctrl-single,pins = <0x1C4  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_6_5_cfg_idle: GPIO_6_5_cfg_idle {
-                     pinctrl-single,pins = <0x1C4  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_6_6_cfg_func: GPIO_6_6_cfg_func {
-                     pinctrl-single,pins = <0x1C8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_6_6_cfg_idle: GPIO_6_6_cfg_idle {
-                     pinctrl-single,pins = <0x1C8  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_6_7_cfg_func: GPIO_6_7_cfg_func {
-                     pinctrl-single,pins = <0x1CC  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_6_7_cfg_idle: GPIO_6_7_cfg_idle {
-                     pinctrl-single,pins = <0x1CC  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_7_0_cfg_func: GPIO_7_0_cfg_func {
-                     pinctrl-single,pins = <0x1D0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_7_0_cfg_idle: GPIO_7_0_cfg_idle {
-                     pinctrl-single,pins = <0x1D0  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_7_1_cfg_func: GPIO_7_1_cfg_func {
-                     pinctrl-single,pins = <0x1D4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_7_1_cfg_idle: GPIO_7_1_cfg_idle {
-                     pinctrl-single,pins = <0x1D4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_7_4_cfg_func: GPIO_7_4_cfg_func {
-                     pinctrl-single,pins = <0x1E0  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_7_4_cfg_idle: GPIO_7_4_cfg_idle {
-                     pinctrl-single,pins = <0x1E0  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_7_5_cfg_func: GPIO_7_5_cfg_func {
-                     pinctrl-single,pins = <0x1E4  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_7_5_cfg_idle: GPIO_7_5_cfg_idle {
-                     pinctrl-single,pins = <0x1E4  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_7_6_cfg_func: GPIO_7_6_cfg_func {
-                     pinctrl-single,pins = <0x1E8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_7_6_cfg_idle: GPIO_7_6_cfg_idle {
-                     pinctrl-single,pins = <0x1E8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_7_7_cfg_func: GPIO_7_7_cfg_func {
-                     pinctrl-single,pins = <0x1EC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_7_7_cfg_idle: GPIO_7_7_cfg_idle {
-                     pinctrl-single,pins = <0x1EC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_8_0_cfg_func: GPIO_8_0_cfg_func {
-                     pinctrl-single,pins = <0x1F0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_8_0_cfg_idle: GPIO_8_0_cfg_idle {
-                     pinctrl-single,pins = <0x1F0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_8_1_cfg_func: GPIO_8_1_cfg_func {
-                     pinctrl-single,pins = <0x1F4  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_8_1_cfg_idle: GPIO_8_1_cfg_idle {
-                     pinctrl-single,pins = <0x1F4  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-       };
-
-    pmx2: pinmux@f8001800 {
-		RSTOUT_N_cfg_func: RSTOUT_N_cfg_func {
-                     pinctrl-single,pins = <0x0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		RSTOUT_N_cfg_idle: RSTOUT_N_cfg_idle {
-                     pinctrl-single,pins = <0x0  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		PMU_PERI_EN_cfg_func: PMU_PERI_EN_cfg_func {
-                     pinctrl-single,pins = <0x4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		PMU_PERI_EN_cfg_idle: PMU_PERI_EN_cfg_idle {
-                     pinctrl-single,pins = <0x4  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		SYSCLK0_EN_cfg_func: SYSCLK0_EN_cfg_func {
-                     pinctrl-single,pins = <0x8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		SYSCLK0_EN_cfg_idle: SYSCLK0_EN_cfg_idle {
-                     pinctrl-single,pins = <0x8  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		JTAG_TDO_cfg_func: JTAG_TDO_cfg_func {
-                     pinctrl-single,pins = <0xC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x20 0x70>;
-		};
-		JTAG_TDO_cfg_idle: JTAG_TDO_cfg_idle {
-                     pinctrl-single,pins = <0xC  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x20 0x70>;
-		};
-
-		GPIO_0_0_cfg_func: GPIO_0_0_cfg_func {
-                     pinctrl-single,pins = <0x10  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_0_0_cfg_idle: GPIO_0_0_cfg_idle {
-                     pinctrl-single,pins = <0x10  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_0_1_cfg_func: GPIO_0_1_cfg_func {
-                     pinctrl-single,pins = <0x14  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_0_1_cfg_idle: GPIO_0_1_cfg_idle {
-                     pinctrl-single,pins = <0x14  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_0_2_cfg_func: GPIO_0_2_cfg_func {
-                     pinctrl-single,pins = <0x18  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_0_2_cfg_idle: GPIO_0_2_cfg_idle {
-                     pinctrl-single,pins = <0x18  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_0_3_cfg_func: GPIO_0_3_cfg_func {
-                     pinctrl-single,pins = <0x1C  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_0_3_cfg_idle: GPIO_0_3_cfg_idle {
-                     pinctrl-single,pins = <0x1C  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_0_4_cfg_func: GPIO_0_4_cfg_func {
-                     pinctrl-single,pins = <0x20  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_0_4_cfg_idle: GPIO_0_4_cfg_idle {
-                     pinctrl-single,pins = <0x20  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_0_5_cfg_func: GPIO_0_5_cfg_func {
-                     pinctrl-single,pins = <0x24  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_0_5_cfg_idle: GPIO_0_5_cfg_idle {
-                     pinctrl-single,pins = <0x24  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_0_6_cfg_func: GPIO_0_6_cfg_func {
-                     pinctrl-single,pins = <0x28  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_0_6_cfg_idle: GPIO_0_6_cfg_idle {
-                     pinctrl-single,pins = <0x28  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_0_7_cfg_func: GPIO_0_7_cfg_func {
-                     pinctrl-single,pins = <0x2C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_0_7_cfg_idle: GPIO_0_7_cfg_idle {
-                     pinctrl-single,pins = <0x2C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_1_0_cfg_func: GPIO_1_0_cfg_func {
-                     pinctrl-single,pins = <0x30  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_1_0_cfg_idle: GPIO_1_0_cfg_idle {
-                     pinctrl-single,pins = <0x30  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_1_1_cfg_func: GPIO_1_1_cfg_func {
-                     pinctrl-single,pins = <0x34  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_1_1_cfg_idle: GPIO_1_1_cfg_idle {
-                     pinctrl-single,pins = <0x34  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_1_2_cfg_func: GPIO_1_2_cfg_func {
-                     pinctrl-single,pins = <0x38  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_1_2_cfg_idle: GPIO_1_2_cfg_idle {
-                     pinctrl-single,pins = <0x38  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_1_3_cfg_func: GPIO_1_3_cfg_func {
-                     pinctrl-single,pins = <0x3C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_1_3_cfg_idle: GPIO_1_3_cfg_idle {
-                     pinctrl-single,pins = <0x3C  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_1_4_cfg_func: GPIO_1_4_cfg_func {
-                     pinctrl-single,pins = <0x40  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_1_4_cfg_idle: GPIO_1_4_cfg_idle {
-                     pinctrl-single,pins = <0x40  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_1_5_cfg_func: GPIO_1_5_cfg_func {
-                     pinctrl-single,pins = <0x44  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_1_5_cfg_idle: GPIO_1_5_cfg_idle {
-                     pinctrl-single,pins = <0x44  0>;
-                     pinctrl-single,bias-pulldown = <2 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_1_6_cfg_func: GPIO_1_6_cfg_func {
-                     pinctrl-single,pins = <0x48  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_1_6_cfg_idle: GPIO_1_6_cfg_idle {
-                     pinctrl-single,pins = <0x48  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_1_7_cfg_func: GPIO_1_7_cfg_func {
-                     pinctrl-single,pins = <0x4C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_1_7_cfg_idle: GPIO_1_7_cfg_idle {
-                     pinctrl-single,pins = <0x4C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_2_0_cfg_func: GPIO_2_0_cfg_func {
-                     pinctrl-single,pins = <0x50  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_2_0_cfg_idle: GPIO_2_0_cfg_idle {
-                     pinctrl-single,pins = <0x50  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_2_1_cfg_func: GPIO_2_1_cfg_func {
-                     pinctrl-single,pins = <0x54  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_2_1_cfg_idle: GPIO_2_1_cfg_idle {
-                     pinctrl-single,pins = <0x54  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_2_2_cfg_func: GPIO_2_2_cfg_func {
-                     pinctrl-single,pins = <0x58  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_2_2_cfg_idle: GPIO_2_2_cfg_idle {
-                     pinctrl-single,pins = <0x58  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_2_3_cfg_func: GPIO_2_3_cfg_func {
-                     pinctrl-single,pins = <0x5C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_2_3_cfg_idle: GPIO_2_3_cfg_idle {
-                     pinctrl-single,pins = <0x5C  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_2_4_cfg_func: GPIO_2_4_cfg_func {
-                     pinctrl-single,pins = <0x60  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_2_4_cfg_idle: GPIO_2_4_cfg_idle {
-                     pinctrl-single,pins = <0x60  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_2_5_cfg_func: GPIO_2_5_cfg_func {
-                     pinctrl-single,pins = <0x64  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_2_5_cfg_idle: GPIO_2_5_cfg_idle {
-                     pinctrl-single,pins = <0x64  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		GPIO_2_6_cfg_func: GPIO_2_6_cfg_func {
-                     pinctrl-single,pins = <0x68  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		GPIO_2_6_cfg_idle: GPIO_2_6_cfg_idle {
-                     pinctrl-single,pins = <0x68  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <1 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		RF_RESET0_cfg_func: RF_RESET0_cfg_func {
-                     pinctrl-single,pins = <0x70  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		RF_RESET0_cfg_idle: RF_RESET0_cfg_idle {
-                     pinctrl-single,pins = <0x70  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-		RF_RESET1_cfg_func: RF_RESET1_cfg_func {
-                     pinctrl-single,pins = <0x74  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-		RF_RESET1_cfg_idle: RF_RESET1_cfg_idle {
-                     pinctrl-single,pins = <0x74  0>;
-                     pinctrl-single,bias-pulldown = <0 2 0 2>;
-                     pinctrl-single,bias-pullup = <0 1 0 1>;
-                     pinctrl-single,drive-strength = <0x00 0x70>;
-		};
-
-       };
-
-   };
+	smb {
+		pmx0: pinmux@f7010000 {
+			pinctrl-names = "default";
+			pinctrl-0 = <
+				&boot_sel_pmx_func
+				&hkadc_ssi_pmx_func
+				&codec_clk_pmx_func
+				&pwm_in_pmx_func
+				&bl_pwm_pmx_func
+				>;
+
+			boot_sel_pmx_func: boot_sel_pmx_func {
+				pinctrl-single,pins = <
+					0x0    MUX_M0	/* BOOT_SEL     (IOMG000) */
+				>;
+			};
+
+			emmc_pmx_func: emmc_pmx_func {
+				pinctrl-single,pins = <
+					0x100  MUX_M0	/* EMMC_CLK     (IOMG064) */
+					0x104  MUX_M0	/* EMMC_CMD     (IOMG065) */
+					0x108  MUX_M0	/* EMMC_DATA0   (IOMG066) */
+					0x10c  MUX_M0	/* EMMC_DATA1   (IOMG067) */
+					0x110  MUX_M0	/* EMMC_DATA2   (IOMG068) */
+					0x114  MUX_M0	/* EMMC_DATA3   (IOMG069) */
+					0x118  MUX_M0	/* EMMC_DATA4   (IOMG070) */
+					0x11c  MUX_M0	/* EMMC_DATA5   (IOMG071) */
+					0x120  MUX_M0	/* EMMC_DATA6   (IOMG072) */
+					0x124  MUX_M0	/* EMMC_DATA7   (IOMG073) */
+				>;
+			};
+
+			sd_pmx_func: sd_pmx_func {
+				pinctrl-single,pins = <
+					0xc    MUX_M0	/* SD_CLK       (IOMG003) */
+					0x10   MUX_M0	/* SD_CMD       (IOMG004) */
+					0x14   MUX_M0	/* SD_DATA0     (IOMG005) */
+					0x18   MUX_M0	/* SD_DATA1     (IOMG006) */
+					0x1c   MUX_M0	/* SD_DATA2     (IOMG007) */
+					0x20   MUX_M0	/* SD_DATA3     (IOMG008) */
+				>;
+			};
+			sd_pmx_idle: sd_pmx_idle {
+				pinctrl-single,pins = <
+					0xc    MUX_M1	/* SD_CLK       (IOMG003) */
+					0x10   MUX_M1	/* SD_CMD       (IOMG004) */
+					0x14   MUX_M1	/* SD_DATA0     (IOMG005) */
+					0x18   MUX_M1	/* SD_DATA1     (IOMG006) */
+					0x1c   MUX_M1	/* SD_DATA2     (IOMG007) */
+					0x20   MUX_M1	/* SD_DATA3     (IOMG008) */
+				>;
+			};
+
+			sdio_pmx_func: sdio_pmx_func {
+				pinctrl-single,pins = <
+					0x128  MUX_M0	/* SDIO_CLK     (IOMG074) */
+					0x12c  MUX_M0	/* SDIO_CMD     (IOMG075) */
+					0x130  MUX_M0	/* SDIO_DATA0   (IOMG076) */
+					0x134  MUX_M0	/* SDIO_DATA1   (IOMG077) */
+					0x138  MUX_M0	/* SDIO_DATA2   (IOMG078) */
+					0x13c  MUX_M0	/* SDIO_DATA3   (IOMG079) */
+				>;
+			};
+			sdio_pmx_idle: sdio_pmx_idle {
+				pinctrl-single,pins = <
+					0x128  MUX_M1	/* SDIO_CLK     (IOMG074) */
+					0x12c  MUX_M1	/* SDIO_CMD     (IOMG075) */
+					0x130  MUX_M1	/* SDIO_DATA0   (IOMG076) */
+					0x134  MUX_M1	/* SDIO_DATA1   (IOMG077) */
+					0x138  MUX_M1	/* SDIO_DATA2   (IOMG078) */
+					0x13c  MUX_M1	/* SDIO_DATA3   (IOMG079) */
+				>;
+			};
+
+			isp_pmx_func: isp_pmx_func {
+				pinctrl-single,pins = <
+					0x24   MUX_M0	/* ISP_PWDN0    (IOMG009) */
+					0x28   MUX_M0	/* ISP_PWDN1    (IOMG010) */
+					0x2c   MUX_M0	/* ISP_PWDN2    (IOMG011) */
+					0x30   MUX_M1	/* ISP_SHUTTER0 (IOMG012) */
+					0x34   MUX_M1	/* ISP_SHUTTER1 (IOMG013) */
+					0x38   MUX_M1	/* ISP_PWM      (IOMG014) */
+					0x3c   MUX_M0	/* ISP_CCLK0    (IOMG015) */
+					0x40   MUX_M0	/* ISP_CCLK1    (IOMG016) */
+					0x44   MUX_M0	/* ISP_RESETB0  (IOMG017) */
+					0x48   MUX_M0	/* ISP_RESETB1  (IOMG018) */
+					0x4c   MUX_M1	/* ISP_STROBE0  (IOMG019) */
+					0x50   MUX_M1	/* ISP_STROBE1  (IOMG020) */
+					0x54   MUX_M0	/* ISP_SDA0     (IOMG021) */
+					0x58   MUX_M0	/* ISP_SCL0     (IOMG022) */
+					0x5c   MUX_M0	/* ISP_SDA1     (IOMG023) */
+					0x60   MUX_M0	/* ISP_SCL1     (IOMG024) */
+				>;
+			};
+
+			hkadc_ssi_pmx_func: hkadc_ssi_pmx_func {
+				pinctrl-single,pins = <
+					0x68   MUX_M0	/* HKADC_SSI    (IOMG026) */
+				>;
+			};
+
+			codec_clk_pmx_func: codec_clk_pmx_func {
+				pinctrl-single,pins = <
+					0x6c   MUX_M0	/* CODEC_CLK    (IOMG027) */
+				>;
+			};
+
+			codec_pmx_func: codec_pmx_func {
+				pinctrl-single,pins = <
+					0x70   MUX_M1	/* DMIC_CLK     (IOMG028) */
+					0x74   MUX_M0	/* CODEC_SYNC   (IOMG029) */
+					0x78   MUX_M0	/* CODEC_DI     (IOMG030) */
+					0x7c   MUX_M0	/* CODEC_DO     (IOMG031) */
+				>;
+			};
+
+			fm_pmx_func: fm_pmx_func {
+				pinctrl-single,pins = <
+					0x80   MUX_M1	/* FM_XCLK      (IOMG032) */
+					0x84   MUX_M1	/* FM_XFS       (IOMG033) */
+					0x88   MUX_M1	/* FM_DI        (IOMG034) */
+					0x8c   MUX_M1	/* FM_DO        (IOMG035) */
+				>;
+			};
+
+			bt_pmx_func: bt_pmx_func {
+				pinctrl-single,pins = <
+					0x90   MUX_M0	/* BT_XCLK      (IOMG036) */
+					0x94   MUX_M0	/* BT_XFS       (IOMG037) */
+					0x98   MUX_M0	/* BT_DI        (IOMG038) */
+					0x9c   MUX_M0	/* BT_DO        (IOMG039) */
+				>;
+			};
+
+			pwm_in_pmx_func: pwm_in_pmx_func {
+				pinctrl-single,pins = <
+					0xb8   MUX_M1	/* PWM_IN       (IOMG046) */
+				>;
+			};
+
+			bl_pwm_pmx_func: bl_pwm_pmx_func {
+				pinctrl-single,pins = <
+					0xbc   MUX_M1	/* BL_PWM       (IOMG047) */
+				>;
+			};
+
+			uart0_pmx_func: uart0_pmx_func {
+				pinctrl-single,pins = <
+					0xc0   MUX_M0	/* UART0_RXD    (IOMG048) */
+					0xc4   MUX_M0	/* UART0_TXD    (IOMG049) */
+				>;
+			};
+
+			uart1_pmx_func: uart1_pmx_func {
+				pinctrl-single,pins = <
+					0xc8   MUX_M0	/* UART1_CTS_N  (IOMG050) */
+					0xcc   MUX_M0	/* UART1_RTS_N  (IOMG051) */
+					0xd0   MUX_M0	/* UART1_RXD    (IOMG052) */
+					0xd4   MUX_M0	/* UART1_TXD    (IOMG053) */
+				>;
+			};
+
+			uart2_pmx_func: uart2_pmx_func {
+				pinctrl-single,pins = <
+					0xd8   MUX_M0	/* UART2_CTS_N  (IOMG054) */
+					0xdc   MUX_M0	/* UART2_RTS_N  (IOMG055) */
+					0xe0   MUX_M0	/* UART2_RXD    (IOMG056) */
+					0xe4   MUX_M0	/* UART2_TXD    (IOMG057) */
+				>;
+			};
+
+			i2c0_pmx_func: i2c0_pmx_func {
+				pinctrl-single,pins = <
+					0xe8   MUX_M0	/* I2C0_SCL     (IOMG058) */
+					0xec   MUX_M0	/* I2C0_SDA     (IOMG059) */
+				>;
+			};
+
+			i2c1_pmx_func: i2c1_pmx_func {
+				pinctrl-single,pins = <
+					0xf0   MUX_M0	/* I2C1_SCL     (IOMG060) */
+					0xf4   MUX_M0	/* I2C1_SDA     (IOMG061) */
+				>;
+			};
+
+			i2c2_pmx_func: i2c2_pmx_func {
+				pinctrl-single,pins = <
+					0xf8   MUX_M0	/* I2C2_SCL     (IOMG062) */
+					0xfc   MUX_M0	/* I2C2_SDA     (IOMG063) */
+				>;
+			};
+		};
+
+		pmx1: pinmux@f7010800 {
+
+			pinctrl-names = "default";
+			pinctrl-0 = <
+				&boot_sel_cfg_func
+				&hkadc_ssi_cfg_func
+				&codec_clk_cfg_func
+				&pwm_in_cfg_func
+				&bl_pwm_cfg_func
+				>;
+
+			boot_sel_cfg_func: boot_sel_cfg_func {
+				pinctrl-single,pins = <
+					0x0    0x0	/* BOOT_SEL     (IOCFG000) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_UP   PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			hkadc_ssi_cfg_func: hkadc_ssi_cfg_func {
+				pinctrl-single,pins = <
+					0x6c   0x0	/* HKADC_SSI    (IOCFG027) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			emmc_clk_cfg_func: emmc_clk_cfg_func {
+				pinctrl-single,pins = <
+					0x104  0x0	/* EMMC_CLK     (IOCFG065) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_08MA DRIVE_MASK>;
+			};
+
+			emmc_cfg_func: emmc_cfg_func {
+				pinctrl-single,pins = <
+					0x108  0x0	/* EMMC_CMD     (IOCFG066) */
+					0x10c  0x0	/* EMMC_DATA0   (IOCFG067) */
+					0x110  0x0	/* EMMC_DATA1   (IOCFG068) */
+					0x114  0x0	/* EMMC_DATA2   (IOCFG069) */
+					0x118  0x0	/* EMMC_DATA3   (IOCFG070) */
+					0x11c  0x0	/* EMMC_DATA4   (IOCFG071) */
+					0x120  0x0	/* EMMC_DATA5   (IOCFG072) */
+					0x124  0x0	/* EMMC_DATA6   (IOCFG073) */
+					0x128  0x0	/* EMMC_DATA7   (IOCFG074) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_UP   PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_04MA DRIVE_MASK>;
+			};
+
+			emmc_rst_cfg_func: emmc_rst_cfg_func {
+				pinctrl-single,pins = <
+					0x12c  0x0	/* EMMC_RST_N   (IOCFG075) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_04MA DRIVE_MASK>;
+			};
+
+			sd_clk_cfg_func: sd_clk_cfg_func {
+				pinctrl-single,pins = <
+					0xc    0x0	/* SD_CLK       (IOCFG003) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_10MA DRIVE_MASK>;
+			};
+			sd_clk_cfg_idle: sd_clk_cfg_idle {
+				pinctrl-single,pins = <
+					0xc    0x0	/* SD_CLK       (IOCFG003) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DOWN PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			sd_cfg_func: sd_cfg_func {
+				pinctrl-single,pins = <
+					0x10   0x0	/* SD_CMD       (IOCFG004) */
+					0x14   0x0	/* SD_DATA0     (IOCFG005) */
+					0x18   0x0	/* SD_DATA1     (IOCFG006) */
+					0x1c   0x0	/* SD_DATA2     (IOCFG007) */
+					0x20   0x0	/* SD_DATA3     (IOCFG008) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_08MA DRIVE_MASK>;
+			};
+			sd_cfg_idle: sd_cfg_idle {
+				pinctrl-single,pins = <
+					0x10   0x0	/* SD_CMD       (IOCFG004) */
+					0x14   0x0	/* SD_DATA0     (IOCFG005) */
+					0x18   0x0	/* SD_DATA1     (IOCFG006) */
+					0x1c   0x0	/* SD_DATA2     (IOCFG007) */
+					0x20   0x0	/* SD_DATA3     (IOCFG008) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DOWN PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			sdio_clk_cfg_func: sdio_clk_cfg_func {
+				pinctrl-single,pins = <
+					0x134  0x0	/* SDIO_CLK     (IOCFG077) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_08MA DRIVE_MASK>;
+			};
+			sdio_clk_cfg_idle: sdio_clk_cfg_idle {
+				pinctrl-single,pins = <
+					0x134  0x0	/* SDIO_CLK     (IOCFG077) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DOWN PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			sdio_cfg_func: sdio_cfg_func {
+				pinctrl-single,pins = <
+					0x138  0x0	/* SDIO_CMD     (IOCFG078) */
+					0x13c  0x0	/* SDIO_DATA0   (IOCFG079) */
+					0x140  0x0	/* SDIO_DATA1   (IOCFG080) */
+					0x144  0x0	/* SDIO_DATA2   (IOCFG081) */
+					0x148  0x0	/* SDIO_DATA3   (IOCFG082) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_UP   PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_04MA DRIVE_MASK>;
+			};
+			sdio_cfg_idle: sdio_cfg_idle {
+				pinctrl-single,pins = <
+					0x138  0x0	/* SDIO_CMD     (IOCFG078) */
+					0x13c  0x0	/* SDIO_DATA0   (IOCFG079) */
+					0x140  0x0	/* SDIO_DATA1   (IOCFG080) */
+					0x144  0x0	/* SDIO_DATA2   (IOCFG081) */
+					0x148  0x0	/* SDIO_DATA3   (IOCFG082) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_UP   PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			isp_cfg_func1: isp_cfg_func1 {
+				pinctrl-single,pins = <
+					0x28   0x0	/* ISP_PWDN0    (IOCFG010) */
+					0x2c   0x0	/* ISP_PWDN1    (IOCFG011) */
+					0x30   0x0	/* ISP_PWDN2    (IOCFG012) */
+					0x34   0x0	/* ISP_SHUTTER0 (IOCFG013) */
+					0x38   0x0	/* ISP_SHUTTER1 (IOCFG014) */
+					0x3c   0x0	/* ISP_PWM      (IOCFG015) */
+					0x40   0x0	/* ISP_CCLK0    (IOCFG016) */
+					0x44   0x0	/* ISP_CCLK1    (IOCFG017) */
+					0x48   0x0	/* ISP_RESETB0  (IOCFG018) */
+					0x4c   0x0	/* ISP_RESETB1  (IOCFG019) */
+					0x50   0x0	/* ISP_STROBE0  (IOCFG020) */
+					0x58   0x0	/* ISP_SDA0     (IOCFG022) */
+					0x5c   0x0	/* ISP_SCL0     (IOCFG023) */
+					0x60   0x0	/* ISP_SDA1     (IOCFG024) */
+					0x64   0x0	/* ISP_SCL1     (IOCFG025) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+			isp_cfg_idle1: isp_cfg_idle1 {
+				pinctrl-single,pins = <
+					0x34   0x0	/* ISP_SHUTTER0 (IOCFG013) */
+					0x38   0x0	/* ISP_SHUTTER1 (IOCFG014) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DOWN PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			isp_cfg_func2: isp_cfg_func2 {
+				pinctrl-single,pins = <
+					0x54   0x0	/* ISP_STROBE1  (IOCFG021) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DOWN PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			codec_clk_cfg_func: codec_clk_cfg_func {
+				pinctrl-single,pins = <
+					0x70   0x0	/* CODEC_CLK    (IOCFG028) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_04MA DRIVE_MASK>;
+			};
+			codec_clk_cfg_idle: codec_clk_cfg_idle {
+				pinctrl-single,pins = <
+					0x70   0x0	/* CODEC_CLK    (IOCFG028) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			codec_cfg_func1: codec_cfg_func1 {
+				pinctrl-single,pins = <
+					0x74   0x0	/* DMIC_CLK     (IOCFG029) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DOWN PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			codec_cfg_func2: codec_cfg_func2 {
+				pinctrl-single,pins = <
+					0x78   0x0	/* CODEC_SYNC   (IOCFG030) */
+					0x7c   0x0	/* CODEC_DI     (IOCFG031) */
+					0x80   0x0	/* CODEC_DO     (IOCFG032) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_04MA DRIVE_MASK>;
+			};
+			codec_cfg_idle2: codec_cfg_idle2 {
+				pinctrl-single,pins = <
+					0x78   0x0	/* CODEC_SYNC   (IOCFG030) */
+					0x7c   0x0	/* CODEC_DI     (IOCFG031) */
+					0x80   0x0	/* CODEC_DO     (IOCFG032) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			fm_cfg_func: fm_cfg_func {
+				pinctrl-single,pins = <
+					0x84   0x0	/* FM_XCLK      (IOCFG033) */
+					0x88   0x0	/* FM_XFS       (IOCFG034) */
+					0x8c   0x0	/* FM_DI        (IOCFG035) */
+					0x90   0x0	/* FM_DO        (IOCFG036) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DOWN PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			bt_cfg_func: bt_cfg_func {
+				pinctrl-single,pins = <
+					0x94   0x0	/* BT_XCLK      (IOCFG037) */
+					0x98   0x0	/* BT_XFS       (IOCFG038) */
+					0x9c   0x0	/* BT_DI        (IOCFG039) */
+					0xa0   0x0	/* BT_DO        (IOCFG040) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+			bt_cfg_idle: bt_cfg_idle {
+				pinctrl-single,pins = <
+					0x94   0x0	/* BT_XCLK      (IOCFG037) */
+					0x98   0x0	/* BT_XFS       (IOCFG038) */
+					0x9c   0x0	/* BT_DI        (IOCFG039) */
+					0xa0   0x0	/* BT_DO        (IOCFG040) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DOWN PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			pwm_in_cfg_func: pwm_in_cfg_func {
+				pinctrl-single,pins = <
+					0xbc   0x0	/* PWM_IN       (IOCFG047) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DOWN PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			bl_pwm_cfg_func: bl_pwm_cfg_func {
+				pinctrl-single,pins = <
+					0xc0   0x0	/* BL_PWM       (IOCFG048) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DOWN PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			uart0_cfg_func1: uart0_cfg_func1 {
+				pinctrl-single,pins = <
+					0xc4   0x0	/* UART0_RXD    (IOCFG049) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_UP   PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			uart0_cfg_func2: uart0_cfg_func2 {
+				pinctrl-single,pins = <
+					0xc8   0x0	/* UART0_TXD    (IOCFG050) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_04MA DRIVE_MASK>;
+			};
+
+			uart1_cfg_func1: uart1_cfg_func1 {
+				pinctrl-single,pins = <
+					0xcc   0x0	/* UART1_CTS_N  (IOCFG051) */
+					0xd4   0x0	/* UART1_RXD    (IOCFG053) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_UP   PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			uart1_cfg_func2: uart1_cfg_func2 {
+				pinctrl-single,pins = <
+					0xd0   0x0	/* UART1_RTS_N  (IOCFG052) */
+					0xd8   0x0	/* UART1_TXD    (IOCFG054) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			uart2_cfg_func: uart2_cfg_func {
+				pinctrl-single,pins = <
+					0xdc   0x0	/* UART2_CTS_N  (IOCFG055) */
+					0xe0   0x0	/* UART2_RTS_N  (IOCFG056) */
+					0xe4   0x0	/* UART2_RXD    (IOCFG057) */
+					0xe8   0x0	/* UART2_TXD    (IOCFG058) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			i2c0_cfg_func: i2c0_cfg_func {
+				pinctrl-single,pins = <
+					0xec   0x0	/* I2C0_SCL     (IOCFG059) */
+					0xf0   0x0	/* I2C0_SDA     (IOCFG060) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			i2c1_cfg_func: i2c1_cfg_func {
+				pinctrl-single,pins = <
+					0xf4   0x0	/* I2C1_SCL     (IOCFG061) */
+					0xf8   0x0	/* I2C1_SDA     (IOCFG062) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			i2c2_cfg_func: i2c2_cfg_func {
+				pinctrl-single,pins = <
+					0xfc   0x0	/* I2C2_SCL     (IOCFG063) */
+					0x100  0x0	/* I2C2_SDA     (IOCFG064) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+		};
+
+		pmx2: pinmux@f8001800 {
+
+			pinctrl-names = "default";
+			pinctrl-0 = <
+				&rstout_n_cfg_func
+				>;
+
+			rstout_n_cfg_func: rstout_n_cfg_func {
+				pinctrl-single,pins = <
+					0x0    0x0	/* RSTOUT_N     (IOCFG000) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			pmu_peri_en_cfg_func: pmu_peri_en_cfg_func {
+				pinctrl-single,pins = <
+					0x4    0x0	/* PMU_PERI_EN  (IOCFG001) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			sysclk0_en_cfg_func: sysclk0_en_cfg_func {
+				pinctrl-single,pins = <
+					0x8    0x0	/* SYSCLK0_EN   (IOCFG002) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
+			jtag_tdo_cfg_func: jtag_tdo_cfg_func {
+				pinctrl-single,pins = <
+					0xc    0x0	/* JTAG_TDO     (IOCFG003) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_08MA DRIVE_MASK>;
+			};
+
+			rf_reset_cfg_func: rf_reset_cfg_func {
+				pinctrl-single,pins = <
+					0x70   0x0	/* RF_RESET0    (IOCFG028) */
+					0x74   0x0	/* RF_RESET1    (IOCFG029) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+		};
+	};
 };

--- a/include/dt-bindings/pinctrl/hisi.h
+++ b/include/dt-bindings/pinctrl/hisi.h
@@ -1,0 +1,59 @@
+/*
+ * This header provides constants for hisilicon pinctrl bindings.
+ *
+ * Copyright (c) 2015 Hisilicon Limited.
+ * Copyright (c) 2015 Linaro Limited.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed "as is" WITHOUT ANY WARRANTY of any
+ * kind, whether express or implied; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _DT_BINDINGS_PINCTRL_HISI_H
+#define _DT_BINDINGS_PINCTRL_HISI_H
+
+/* iomg bit definition */
+#define MUX_M0		0
+#define MUX_M1		1
+#define MUX_M2		2
+#define MUX_M3		3
+#define MUX_M4		4
+#define MUX_M5		5
+#define MUX_M6		6
+#define MUX_M7		7
+
+/* iocg bit definition */
+#define PULL_MASK	(3)
+#define PULL_DIS	(0)
+#define PULL_UP		(1 << 0)
+#define PULL_DOWN	(1 << 1)
+
+/* drive strength definition */
+#define DRIVE_MASK	(7 << 4)
+#define DRIVE1_02MA	(0 << 4)
+#define DRIVE1_04MA	(1 << 4)
+#define DRIVE1_08MA	(2 << 4)
+#define DRIVE1_10MA	(3 << 4)
+#define DRIVE2_02MA	(0 << 4)
+#define DRIVE2_04MA	(1 << 4)
+#define DRIVE2_08MA	(2 << 4)
+#define DRIVE2_10MA	(3 << 4)
+#define DRIVE3_04MA	(0 << 4)
+#define DRIVE3_08MA	(1 << 4)
+#define DRIVE3_12MA	(2 << 4)
+#define DRIVE3_16MA	(3 << 4)
+#define DRIVE3_20MA	(4 << 4)
+#define DRIVE3_24MA	(5 << 4)
+#define DRIVE3_32MA	(6 << 4)
+#define DRIVE3_40MA	(7 << 4)
+#define DRIVE4_02MA	(0 << 4)
+#define DRIVE4_04MA	(2 << 4)
+#define DRIVE4_08MA	(4 << 4)
+#define DRIVE4_10MA	(6 << 4)
+
+#endif


### PR DESCRIPTION
Polish pinctrl setting for hikey  board, so that it can be more readable after defined bits for IOCG and IOMG registers; and also define pin groups based on device modules.
