### PR TITLE
gpu/drm: hisilicon: fix hang issue during power off

### DIFF
--- a/drivers/gpu/drm/hisilicon/hisi_drm_ade.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_ade.c
@@ -295,7 +295,7 @@ static void hisi_drm_crtc_dpms(struct drm_crtc *crtc, int mode)
 
 	if (mode == DRM_MODE_DPMS_ON)
 		hisi_drm_crtc_ade_enable(crtc_ade);
-	else
+	else if (mode == DRM_MODE_DPMS_OFF)
 		hisi_drm_crtc_ade_disable(crtc_ade);
 
 	crtc_ade->dpms = mode;

--- a/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
@@ -705,8 +705,10 @@ static void hisi_drm_encoder_dpms(struct drm_encoder *encoder, int mode)
 	case DRM_MODE_DPMS_ON:
 		hisi_dsi_enable(dsi);
 		break;
-	default:
+	case DRM_MODE_DPMS_OFF:
 		hisi_dsi_disable(dsi);
+		break;
+	default:
 		break;
 	}
 


### PR DESCRIPTION
When power off display, it will call the dpms callback function for
suspend and power off; in the old code it will call the power down flow
for twice, one time is for suspend and another is for power off; because
the first time has disabled the clock domain for the module, so in the
second time it access the module's register, it will introduce the
external bus error and hang.

So this patch will only turn off the module for power off flow.

Signed-off-by: Leo Yan leo.yan@linaro.org
