### PR TITLE
arm64: topology: adjust log level

### DIFF
--- a/arch/arm64/kernel/topology.c
+++ b/arch/arm64/kernel/topology.c
@@ -292,7 +292,7 @@ static void __init parse_dt_cpu_power(void)
 
 		rate = of_get_property(cn, "clock-frequency", &len);
 		if (!rate || len != 4) {
-			pr_err("%s: Missing clock-frequency property\n",
+			pr_warn("%s: Missing clock-frequency property\n",
 				cn->full_name);
 			continue;
 		}


### PR DESCRIPTION
If cpu node don't pass the cpu frequency from DT, then it will report
the error log. Now change this log as a warning.

Signed-off-by: Leo Yan leo.yan@linaro.org
