### PR TITLE
Revert "Input: evdev - Add ioctl to block suspend while event queue is n...

### DIFF
--- a/drivers/input/evdev.c
+++ b/drivers/input/evdev.c
@@ -26,7 +26,6 @@
 #include <linux/major.h>
 #include <linux/device.h>
 #include <linux/cdev.h>
-#include <linux/wakelock.h>
 #include "input-compat.h"
 
 struct evdev {
@@ -47,9 +46,6 @@ struct evdev_client {
 	unsigned int tail;
 	unsigned int packet_head; /* [future] position of the first element of next packet */
 	spinlock_t buffer_lock; /* protects access to buffer, head and tail */
-	struct wake_lock wake_lock;
-	bool use_wake_lock;
-	char name[28];
 	struct fasync_struct *fasync;
 	struct evdev *evdev;
 	struct list_head node;
@@ -153,14 +149,10 @@ static void __pass_event(struct evdev_client *client,
 		client->buffer[client->tail].value = 0;
 
 		client->packet_head = client->tail;
-		if (client->use_wake_lock)
-			wake_unlock(&client->wake_lock);
 	}
 
 	if (event->type == EV_SYN && event->code == SYN_REPORT) {
 		client->packet_head = client->head;
-		if (client->use_wake_lock)
-			wake_lock(&client->wake_lock);
 		kill_fasync(&client->fasync, SIGIO, POLL_IN);
 	}
 }
@@ -379,14 +371,10 @@ static int evdev_release(struct inode *inode, struct file *file)
 
 	evdev_detach_client(evdev, client);
 
-	if (client->use_wake_lock)
-		wake_lock_destroy(&client->wake_lock);
-
 	if (is_vmalloc_addr(client))
 		vfree(client);
 	else
 		kfree(client);
-	kfree(client);
 
 	evdev_close_device(evdev);
 
@@ -419,8 +407,6 @@ static int evdev_open(struct inode *inode, struct file *file)
 
 	client->bufsize = bufsize;
 	spin_lock_init(&client->buffer_lock);
-	snprintf(client->name, sizeof(client->name), "%s-%d",
-			dev_name(&evdev->dev), task_tgid_vnr(current));
 	client->evdev = evdev;
 	evdev_attach_client(evdev, client);
 
@@ -487,9 +473,6 @@ static int evdev_fetch_next_event(struct evdev_client *client,
 	if (have_event) {
 		*event = client->buffer[client->tail++];
 		client->tail &= client->bufsize - 1;
-		if (client->use_wake_lock &&
-		    client->packet_head == client->tail)
-			wake_unlock(&client->wake_lock);
 	}
 
 	spin_unlock_irq(&client->buffer_lock);
@@ -829,35 +812,6 @@ static int evdev_revoke(struct evdev *evdev, struct evdev_client *client,
 }
 */
 
-static int evdev_enable_suspend_block(struct evdev *evdev,
-				      struct evdev_client *client)
-{
-	if (client->use_wake_lock)
-		return 0;
-
-	spin_lock_irq(&client->buffer_lock);
-	wake_lock_init(&client->wake_lock, WAKE_LOCK_SUSPEND, client->name);
-	client->use_wake_lock = true;
-	if (client->packet_head != client->tail)
-		wake_lock(&client->wake_lock);
-	spin_unlock_irq(&client->buffer_lock);
-	return 0;
-}
-
-static int evdev_disable_suspend_block(struct evdev *evdev,
-				       struct evdev_client *client)
-{
-	if (!client->use_wake_lock)
-		return 0;
-
-	spin_lock_irq(&client->buffer_lock);
-	client->use_wake_lock = false;
-	wake_lock_destroy(&client->wake_lock);
-	spin_unlock_irq(&client->buffer_lock);
-
-	return 0;
-}
-
 static long evdev_do_ioctl(struct file *file, unsigned int cmd,
 			   void __user *p, int compat_mode)
 {
@@ -950,15 +904,6 @@ static long evdev_do_ioctl(struct file *file, unsigned int cmd,
 
 	case EVIOCSKEYCODE_V2:
 		return evdev_handle_set_keycode_v2(dev, p);
-
-	case EVIOCGSUSPENDBLOCK:
-		return put_user(client->use_wake_lock, ip);
-
-	case EVIOCSSUSPENDBLOCK:
-		if (p)
-			return evdev_enable_suspend_block(evdev, client);
-		else
-			return evdev_disable_suspend_block(evdev, client);
 	}
 
 	size = _IOC_SIZE(cmd);

--- a/include/uapi/linux/input.h
+++ b/include/uapi/linux/input.h
@@ -156,9 +156,6 @@ struct input_keymap_entry {
 /* HACK: disable conflicting EVIOCREVOKE until Android userspace stops using EVIOCSSUSPENDBLOCK */
 /*#define EVIOCREVOKE		_IOW('E', 0x91, int)*/			/* Revoke device access */
 
-#define EVIOCGSUSPENDBLOCK	_IOR('E', 0x91, int)			/* get suspend block enable */
-#define EVIOCSSUSPENDBLOCK	_IOW('E', 0x91, int)			/* set suspend block enable */
-
 #define EVIOCSCLOCKID		_IOW('E', 0xa0, int)			/* Set clockid to be used for timestamps */
 
 /*


### PR DESCRIPTION
https://github.com/96boards/bugs/issues/36

This reverts commit 6e71fda4b35e9b8b4f2f009b9d2b70214ea2db3a.
Cause kernel panic via cat /dev/input/eventx while attaching keyboard/mouse

Signed-off-by: Zhangfei Gao zhangfei.gao@linaro.org
