### PR TITLE
gpu/drm: hisilicon: fix hang issue during xwindows suspend

### DIFF
--- a/drivers/gpu/drm/hisilicon/hisi_drm_ade.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_ade.c
@@ -94,8 +94,7 @@ enum {
 
 
 struct hisi_drm_ade_crtc {
-
-	int dpms;
+	bool enable;
 	u8 __iomem  *ade_base;
 	u8 __iomem  *media_base;
 	u32 ade_core_rate;
@@ -288,17 +287,18 @@ static void ldi_init(struct hisi_drm_ade_crtc *crtc_ade)
 static void hisi_drm_crtc_dpms(struct drm_crtc *crtc, int mode)
 {
 	struct hisi_drm_ade_crtc *crtc_ade = to_hisi_crtc(crtc);
+	bool enable = (mode == DRM_MODE_DPMS_ON);
 
 	DRM_DEBUG_DRIVER("crtc_dpms  enter successfully.\n");
-	if (crtc_ade->dpms == mode)
+	if (crtc_ade->enable == enable)
 		return;
 
-	if (mode == DRM_MODE_DPMS_ON)
+	if (enable)
 		hisi_drm_crtc_ade_enable(crtc_ade);
 	else
 		hisi_drm_crtc_ade_disable(crtc_ade);
 
-	crtc_ade->dpms = mode;
+	crtc_ade->enable = enable;
 	DRM_DEBUG_DRIVER("crtc_dpms exit successfully.\n");
 }
 
@@ -459,7 +459,7 @@ static int hisi_drm_crtc_create(struct hisi_drm_ade_crtc *crtc_ade)
 	struct drm_crtc *crtc = &crtc_ade->crtc;
 	int ret;
 
-	crtc_ade->dpms = DRM_MODE_DPMS_OFF;
+	crtc_ade->enable = false;
 	ret = drm_crtc_init(crtc_ade->drm_dev, crtc, &crtc_funcs);
 	if (ret < 0)
 		return ret;

--- a/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
@@ -100,7 +100,7 @@ struct hisi_dsi {
 	u32 vc;
 	u32 mode_flags;
 
-	int dpms;
+	bool enable;
 };
 
 enum {
@@ -695,20 +695,17 @@ static void hisi_drm_encoder_dpms(struct drm_encoder *encoder, int mode)
 {
 	struct hisi_dsi *dsi = encoder_to_dsi(encoder);
 	struct drm_encoder_slave_funcs *sfuncs = get_slave_funcs(encoder);
+	bool enable = (mode == DRM_MODE_DPMS_ON);
 
 	DRM_DEBUG_DRIVER("enter. dpms=%d\n", mode);
-	if (dsi->dpms == mode)
+	if (dsi->enable == enable)
 		return;
 
-	dsi->dpms = mode;
-	switch (mode) {
-	case DRM_MODE_DPMS_ON:
+	if (enable)
 		hisi_dsi_enable(dsi);
-		break;
-	default:
+	else
 		hisi_dsi_disable(dsi);
-		break;
-	}
+	dsi->enable = enable;
 
 	if (sfuncs->dpms)
 		sfuncs->dpms(encoder, mode);
@@ -928,7 +925,7 @@ static int hisi_drm_encoder_create(struct drm_device *dev, struct hisi_dsi *dsi)
 	int ret;
 
 	DRM_DEBUG_DRIVER("enter.\n");
-	dsi->dpms = DRM_MODE_DPMS_OFF;
+	dsi->enable = false;
 	encoder->possible_crtcs = 1;
 	drm_encoder_init(dev, encoder, &hisi_encoder_funcs, DRM_MODE_ENCODER_TMDS);
 	drm_encoder_helper_add(encoder, &hisi_encoder_helper_funcs);


### PR DESCRIPTION
This patch avoid to call power off functions when they have been called once.
Otherwise it will lead to mismatch of clk_disable_unprepare/clk_prepare_enable.
This is the root cause of system hang when xwindows suspend.

Signed-off-by: xinliang.liu xinliang.liu@linaro.org
