### PR TITLE
phy: phy-hisi: remove unnecessary vector

### DIFF
--- a/drivers/usb/phy/phy-hisi.c
+++ b/drivers/usb/phy/phy-hisi.c
@@ -231,10 +231,6 @@ static int mv_otg_set_host(struct usb_otg *otg,
 static int mv_otg_set_peripheral(struct usb_otg *otg,
 				 struct usb_gadget *gadget)
 {
-	struct hisi_priv *priv;
-
-	priv = container_of(otg->phy, struct hisi_priv, phy);
-
 	otg->gadget = gadget;
 	return 0;
 }


### PR DESCRIPTION
fix kbuild error:
fengguang.wu@intel.com
[geoff-kexec:hikey-mainline-rebase 5/61] drivers/usb/phy/phy-hisi.c:232:9: note: in expansion of macro 'container_of'
