### PR TITLE
perf(pmu event): hikey: enable pmu on hikey board

### DIFF
--- a/arch/arm64/boot/dts/hi6220.dtsi
+++ b/arch/arm64/boot/dts/hi6220.dtsi
@@ -216,6 +216,11 @@
 		clock-frequency = <1200000>;
 	};
 
+	pmu {
+		compatible = "arm,armv8-pmuv3";
+		interrupts = <0 99 4>;
+	};
+
 	smb {
 		compatible = "simple-bus";
 		#address-cells = <2>;


### PR DESCRIPTION
hikey board mux the PMU interrupt of every core into a single
SPI.We need to determine which core raised the interrupt so handle
it.

Signed-off-by: Fei Wang w.f@huawei.com
