### PR TITLE
btwilink: remove macro DEBUG

### DIFF
--- a/drivers/bluetooth/btwilink.c
+++ b/drivers/bluetooth/btwilink.c
@@ -22,7 +22,6 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
-#define DEBUG
 #include <linux/platform_device.h>
 #include <net/bluetooth/bluetooth.h>
 #include <net/bluetooth/hci_core.h>


### PR DESCRIPTION
Remove macro DEBUG so can remove mass debug info.

Signed-off-by: Leo Yan leo.yan@linaro.org
