### PR TITLE
ARM64: hi6220: enable ldo21 by default

### DIFF
--- a/arch/arm64/boot/dts/hi6220.dtsi
+++ b/arch/arm64/boot/dts/hi6220.dtsi
@@ -895,6 +895,25 @@
                         hisilicon,num_consumer_supplies = <1>;
                         hisilicon,consumer-supplies = "emmc_vddm";
                 };
+		ldo21: regulator@a40 {
+			compatible = "hisilicon,hi6552-regulator-pmic";
+			regulator-name = "ldo21";
+			regulator-min-microvolt = <1650000>;
+			regulator-max-microvolt = <2000000>;
+			regulator-always-on;
+			hisilicon,valid-modes-mask = <0x02>;
+			hisilicon,valid-ops-mask = <0x01d>;
+			hisilicon,initial-mode = <0x02>;
+			hisilicon,regulator-type = <0x01>;
+
+			hisilicon,off-on-delay = <120>;
+			hisilicon,ctrl-regs = <0x02f 0x030 0x031>;
+			hisilicon,ctrl-data = <0x4 0x1>;
+			hisilicon,vset-regs = <0x086>;
+			hisilicon,vset-data = <0 0x3>;
+			hisilicon,regulator-n-vol = <8>;
+			hisilicon,vset-table = <1650000>,<1700000>,<1750000>,<1800000>,<1850000>,<1900000>,<1950000>,<2000000>;
+		};
                 ldo22: regulator@a41 {
                         compatible = "hisilicon,hi6552-regulator-pmic";
                         regulator-name = "ldo22";


### PR DESCRIPTION
Since LDO21 is used on low speed expansion board, make it always on to
debug LS expansion board easier.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
