### PR TITLE
dts: hikey: remove always-on in wlan_en regulator

### DIFF
--- a/arch/arm64/boot/dts/hi6220-hikey.dts
+++ b/arch/arm64/boot/dts/hi6220-hikey.dts
@@ -193,8 +193,5 @@
 		/* WLAN card specific delay */
 		startup-delay-us = <70000>;
 		enable-active-high;
-
-		/* temp solution */
-		regulator-always-on;
 	};
 };


### PR DESCRIPTION
WLAN_EN pin should be controllable by mmmc driver on each of its up
and down.

Otherwise, WLAN module cannot be properly reset. One noticeable failure
happens at the second time you run 'ifconfig wlan0 up'.

Signed-off-by: Guodong Xu guodong.xu@linaro.org
