### PR TITLE
Bluetooth: tty_hci: add LED support

### DIFF
--- a/drivers/misc/ti-st/Makefile
+++ b/drivers/misc/ti-st/Makefile
@@ -5,3 +5,5 @@
 obj-$(CONFIG_TI_ST) 		+= st_drv.o
 st_drv-objs			:= st_core.o st_kim.o st_ll.o
 obj-$(CONFIG_ST_HCI)		+= tty_hci.o
+
+ccflags-y += -Inet/bluetooth

--- a/net/bluetooth/led.c
+++ b/net/bluetooth/led.c
@@ -19,6 +19,7 @@ void bluetooth_led_rx(struct hci_dev *hdev)
 		return;
 	led_trigger_blink_oneshot(hdev->rx_led, &led_delay, &led_delay, 0);
 }
+EXPORT_SYMBOL_GPL(bluetooth_led_rx);
 
 void bluetooth_led_tx(struct hci_dev *hdev)
 {
@@ -27,6 +28,7 @@ void bluetooth_led_tx(struct hci_dev *hdev)
 		return;
 	led_trigger_blink_oneshot(hdev->tx_led, &led_delay, &led_delay, 0);
 }
+EXPORT_SYMBOL_GPL(bluetooth_led_tx);
 
 void bluetooth_led_names(struct hci_dev *hdev)
 {


### PR DESCRIPTION
Add LED support for tty HCI driver. Two triggers are used, and each for one
traffic direction: tx and rx.

Signed-off-by: Guodong Xu guodong.xu@linaro.org
