### PR TITLE
hikey: dts: set pin as nopull for wl module

### DIFF
--- a/arch/arm64/boot/dts/hi6220-hikey.dts
+++ b/arch/arm64/boot/dts/hi6220-hikey.dts
@@ -111,8 +111,8 @@
 		/* WL_EN */
 		vmmc-supply = <&wlan_en_reg>;
 		pinctrl-names = "default", "idle";
-		pinctrl-0 = <&sdio_pmx_func &sdio_clk_cfg_func &sdio_cfg_func>;
-		pinctrl-1 = <&sdio_pmx_idle &sdio_clk_cfg_idle &sdio_cfg_idle>;
+		pinctrl-0 = <&sdio_pmx_func &sdio_clk_cfg_func &sdio_cfg_func &wl_en_func>;
+		pinctrl-1 = <&sdio_pmx_idle &sdio_clk_cfg_idle &sdio_cfg_idle &wl_en_func>;
 	};
 
 	wlcore {

--- a/arch/arm64/boot/dts/hikey-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/hikey-pinctrl.dtsi
@@ -371,6 +371,16 @@
 				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
 			};
 
+			wl_en_func: wl_en_func {
+				pinctrl-single,pins = <
+					0x024  0x0	/* GPIO0_5	(IOCFG009) */
+					0x04c  0x0	/* GPIO1_7	(IOCFG019) */
+				>;
+				pinctrl-single,bias-pulldown  = <PULL_DIS  PULL_DOWN PULL_DIS  PULL_DOWN>;
+				pinctrl-single,bias-pullup    = <PULL_DIS  PULL_UP   PULL_DIS  PULL_UP>;
+				pinctrl-single,drive-strength = <DRIVE1_02MA DRIVE_MASK>;
+			};
+
 			isp_cfg_func1: isp_cfg_func1 {
 				pinctrl-single,pins = <
 					0x28   0x0	/* ISP_PWDN0    (IOCFG010) */


### PR DESCRIPTION
Set the WL_EN & BT_EN as nopull configuration mode. Otherwise,
these two pins couldn't be driven successfully by setting GPIO
level.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org

This commit is necessary for UEFI loading kernel.
