### PR TITLE
dts: hi6220: sd not support uhs mode

### DIFF
--- a/arch/arm64/boot/dts/hi6220.dtsi
+++ b/arch/arm64/boot/dts/hi6220.dtsi
@@ -1025,8 +1025,6 @@
 		card-detect-delay = <200>;
 		hisilicon,peripheral-syscon = <&ao_ctrl>;
 		cap-sd-highspeed;
-		sd-uhs-sdr12;
-		sd-uhs-sdr25;
 		reg = <0x0 0xf723e000 0x0 0x1000>;
 		interrupts = <0x0 0x49 0x4>;
 		clocks = <&clock_sys HI6220_MMC1_CIUCLK>, <&clock_sys HI6220_MMC1_CLK>;


### PR DESCRIPTION
Find 1.8v voltage switch still has issue
So only support hs mode, and do not support sdr mode until 1.8v voltage switch is supported

Signed-off-by: Zhangfei Gao zhangfei.gao@linaro.org
