### PR TITLE
gator: Enable multiple source copies to exist in Android build enviro…

### DIFF
--- a/tools/gator/daemon/Android.mk
+++ b/tools/gator/daemon/Android.mk
@@ -1,4 +1,8 @@
 LOCAL_PATH := $(call my-dir)
+
+# Don't use this file if GATOR_DAEMON_PATH is set and we're not under that path
+ifneq ($(and $(GATOR_DAEMON_PATH),$(filter $(patsubst %/,%,$(GATOR_DAEMON_PATH))/%,$(LOCAL_PATH)/)),)
+
 include $(CLEAR_VARS)
 
 XML_H := $(shell cd $(LOCAL_PATH) && make events_xml.h defaults_xml.h)
@@ -74,3 +78,5 @@ LOCAL_MODULE := gatord
 LOCAL_MODULE_TAGS := optional
 
 include $(BUILD_EXECUTABLE)
+
+endif


### PR DESCRIPTION
…nments

An Android build environment may contain multiple copies of the gator
source code, e.g. if it's been copied into a kernel tree as well as
having a standalone copy, or if there are two kernel trees with copies.

As Android builds tend to include all Android.mk it finds, this can
lead to build errors because there is more that one makefile trying to
build the daemon.

To allow this situation to be catered for we update Android.mk so that
if the variable GATOR_DAEMON_PATH is defined, and the makefile doesn't
live under that path, then the makefile contents are ignored. An Android
build environment can then set GATOR_DAEMON_PATH to specify the copy
it wants to use.

Signed-off-by: Jon Medhurst tixy@linaro.org
