### PR TITLE
gpu/drm: hisilicon: set different color pattern for Android and X

### DIFF
--- a/drivers/gpu/drm/hisilicon/hisi_drm_ade.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_ade.c
@@ -388,8 +388,14 @@ static int hisi_drm_crtc_mode_set_base(struct drm_crtc *crtc, int x, int y,
 		writel((ADE_RGB_565 << 16) & 0x1f0000,
 		    ade_base + RD_CH_DISP_CTRL_REG);
 	else if (32 == fb->bits_per_pixel)
+#if defined(CONFIG_ANDROID)
 		writel((ADE_ARGB_8888 << 16) & 0x1f0000,
 		    ade_base + RD_CH_DISP_CTRL_REG);
+#else
+		writel((ADE_ABGR_8888 << 16) & 0x1f0000,
+		    ade_base + RD_CH_DISP_CTRL_REG);
+#endif /* CONFIG_ANDROID */
+
 	writel(display_addr, ade_base + RD_CH_DISP_ADDR_REG);
 	writel((fb_hight << 16) | stride, ade_base + RD_CH_DISP_SIZE_REG);
 	writel(stride, ade_base + RD_CH_DISP_STRIDE_REG);


### PR DESCRIPTION
This is a hacking solution for differentiating color patterns between
Android and X.

Formal solution will come next, which setting the pattern
according to actual use instead of static #if defined.

Signed-off-by: xinliang.liu xinliang.liu@linaro.org
Signed-off-by: Guodong Xu guodong.xu@linaro.org
