### PR TITLE
Revert "power: reset: support reboot for hi6220"

### DIFF
--- a/drivers/power/reset/hisi-reboot.c
+++ b/drivers/power/reset/hisi-reboot.c
@@ -21,13 +21,12 @@
 #include <asm/proc-fns.h>
 #include <asm/system_misc.h>
 
-static void __iomem *reboot_base;
+static void __iomem *base;
 static u32 reboot_offset;
-static u32 reboot_magic_num;
 
 static void hisi_restart(enum reboot_mode mode, const char *cmd)
 {
-	writel_relaxed(reboot_magic_num, reboot_base + reboot_offset);
+	writel_relaxed(0xdeadbeef, base + reboot_offset);
 
 	while (1)
 		cpu_do_idle();
@@ -35,7 +34,6 @@ static void hisi_restart(enum reboot_mode mode, const char *cmd)
 
 static int hisi_reboot_probe(struct platform_device *pdev)
 {
-	void __iomem *base;
 	struct device_node *np = pdev->dev.of_node;
 
 	base = of_iomap(np, 0);
@@ -49,12 +47,6 @@ static int hisi_reboot_probe(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
-	if (of_machine_is_compatible("hisilicon,sysctrl"))
-		reboot_magic_num = 0xdeadbeef;
-	else /* hisilicon,aoctrl */
-		reboot_magic_num = 0x48698284;
-
-	reboot_base = base;
 	arm_pm_restart = hisi_restart;
 
 	return 0;
@@ -62,7 +54,6 @@ static int hisi_reboot_probe(struct platform_device *pdev)
 
 static struct of_device_id hisi_reboot_of_match[] = {
 	{ .compatible = "hisilicon,sysctrl" },
-	{ .compatible = "hisilicon,aoctrl" },
 	{}
 };
 


### PR DESCRIPTION
In the commit 40a4407953a49b2fc3518a34edf615415e2bcd6b "dts: hi6220:
update reboot" has changed to use syscon-reset driver, so can revert the
previous modification for hisi's reset driver.
