### PR TITLE
arm64: dts: enable psci in hikey

### DIFF
--- a/arch/arm64/boot/dts/hi6220.dtsi
+++ b/arch/arm64/boot/dts/hi6220.dtsi
@@ -9,6 +9,11 @@
 #include <dt-bindings/pinctrl/hisi.h>
 
 / {
+	psci {
+		compatible = "arm,psci-0.2";
+		method = "smc";
+	};
+
 	cpus {
 		#address-cells = <2>;
 		#size-cells = <0>;
@@ -17,8 +22,7 @@
 			compatible = "arm,cortex-a53", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x0>;
-                        enable-method = "spin-table";
-                        cpu-release-addr = <0x0 0x740fff8>;
+			enable-method = "psci";
 			clocks = <&clock_acpu HI6220_STUB_ACPU0>;
 			clock-names = "acpu0";
 			clock-latency = <0>;
@@ -36,57 +40,44 @@
 			compatible = "arm,cortex-a53", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x1>;
-			enable-method = "spin-table";
-                        cpu-release-addr = <0x0 0x740fff8>;
-			clock-latency = <0>;
+			enable-method = "psci";
 		};
 		cpu2: cpu@2 {
 			compatible = "arm,cortex-a53", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x2>;
-			enable-method = "spin-table";
-                        cpu-release-addr = <0x0 0x740fff8>;
-			clock-latency = <0>;
+			enable-method = "psci";
 		};
 		cpu3: cpu@3 {
 			compatible = "arm,cortex-a53", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x3>;
-			enable-method = "spin-table";
-                        cpu-release-addr = <0x0 0x740fff8>;
-			clock-latency = <0>;
+			enable-method = "psci";
 		};
 		cpu4: cpu@4 {
 			compatible = "arm,cortex-a53", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x100>;
-			enable-method = "spin-table";
-                        cpu-release-addr = <0x0 0x740fff8>;
+			enable-method = "psci";
 			clock-latency = <0>;
 		};
 		cpu5: cpu@5 {
 			compatible = "arm,cortex-a53", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x101>;
-			enable-method = "spin-table";
-                        cpu-release-addr = <0x0 0x740fff8>;
-			clock-latency = <0>;
+			enable-method = "psci";
 		};
 		cpu6: cpu@6 {
 			compatible = "arm,cortex-a53", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x102>;
-			enable-method = "spin-table";
-                        cpu-release-addr = <0x0 0x740fff8>;
-			clock-latency = <0>;
+			enable-method = "psci";
 		};
 		cpu7: cpu@7 {
 			compatible = "arm,cortex-a53", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x103>;
-			enable-method = "spin-table";
-                        cpu-release-addr = <0x0 0x740fff8>;
-			clock-latency = <0>;
+			enable-method = "psci";
 		};
 
 		cpu-map {
@@ -211,7 +202,6 @@
 			     <1 14 0xff08>,
 			     <1 11 0xff08>,
 			     <1 10 0xff08>;
-		clock-frequency = <1200000>;
 	};
 
 	reboot {


### PR DESCRIPTION
Enable psci in Hisilicon Hi6220 HiKey board.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
Signed-off-by: Leo Yan leo.yan@linaro.org
