### PR TITLE
clk: hi6220: syspll is set by bootloader. Read from registers in clk …

### DIFF
--- a/drivers/clk/hisilicon/clk-hi6220.c
+++ b/drivers/clk/hisilicon/clk-hi6220.c
@@ -10,15 +10,15 @@
  * published by the Free Software Foundation.
  */
 
-#include <linux/kernel.h>
+#include <linux/clk.h>
 #include <linux/clk-provider.h>
 #include <linux/clkdev.h>
 #include <linux/io.h>
+#include <linux/kernel.h>
 #include <linux/of.h>
 #include <linux/of_address.h>
 #include <linux/of_device.h>
 #include <linux/slab.h>
-#include <linux/clk.h>
 
 #include <dt-bindings/clock/hi6220-clock.h>
 
@@ -35,7 +35,7 @@ static struct hisi_fixed_rate_clock hi6220_fixed_rate_clks[] __initdata = {
 	{ HI6220_PLL_BBP,	"bbppll0",	NULL, CLK_IS_ROOT, 245760000, },
 	{ HI6220_PLL_GPU,	"gpupll",	NULL, CLK_IS_ROOT, 1000000000,},
 	{ HI6220_PLL1_DDR,	"ddrpll1",	NULL, CLK_IS_ROOT, 1066000000,},
-	{ HI6220_PLL_SYS,	"syspll",	NULL, CLK_IS_ROOT, 1200000000,},
+	{ HI6220_PLL_SYS,	"syspll",	NULL, CLK_IS_ROOT, 1190494208,},
 	{ HI6220_PLL_SYS_MEDIA,	"media_syspll",	NULL, CLK_IS_ROOT, 1200000000,},
 	{ HI6220_DDR_SRC,	"ddr_sel_src",  NULL, CLK_IS_ROOT, 1200000000,},
 	{ HI6220_PLL_MEDIA,	"media_pll",    NULL, CLK_IS_ROOT, 1440000000,},
@@ -73,13 +73,41 @@ static struct hisi_gate_clock hi6220_separated_gate_clks_ao[] __initdata = {
 	{ HI6220_RTC1_PCLK,  "rtc1_pclk",  "clk_tcxo", CLK_SET_RATE_PARENT|CLK_IGNORE_UNUSED, 0x630, 26, 0, },
 };
 
+#define SOC_PERI_SCTRL_BASE_ADDR	0xF7030000 /* peri ctrl base addr */
+#define SC_PERIPH_CTRL14		0x02C
+#define SC_PERIPH_STAT1			0x094
+
 static struct hisi_clock_data *clk_data_ao;
 
 static void __init hi6220_clk_ao_init(struct device_node *np)
 {
+	void __iomem *peri_base;
+	unsigned int syspll_freq;
+	int i;
+
 	clk_data_ao = hisi_clk_init(np, HI6220_AO_NR_CLKS);
 	if (!clk_data_ao)
 		return;
+
+	/* SYSPLL is set by bootloader. Read it */
+	peri_base = ioremap(SOC_PERI_SCTRL_BASE_ADDR, 0x1000);
+	/* 0x2101 means to calculate clk_sys_pll */
+	writel(0x2101, peri_base + SC_PERIPH_CTRL14);
+	/* read back the calculated value */
+	syspll_freq = readl(peri_base + SC_PERIPH_STAT1);
+	pr_debug("SYSPLL: syspll_freq is read: %d\n", syspll_freq);
+	if (syspll_freq == 0x00020000 || syspll_freq == 0)
+		syspll_freq = 1200000000;
+	pr_debug("SYSPLL: syspll_freq will be set to: %d\n", syspll_freq);
+
+	for (i = 0; i < ARRAY_SIZE(hi6220_fixed_rate_clks); i++) {
+		if (hi6220_fixed_rate_clks[i].id == HI6220_PLL_SYS) {
+			hi6220_fixed_rate_clks[i].fixed_rate = syspll_freq;
+			printk("SYSPLL: modified fix_rate[%d], id=%d, f=%d\n", \
+				i, hi6220_fixed_rate_clks[i].id, syspll_freq);
+			break;
+		}
+	}
 
 	hisi_clk_register_fixed_rate(hi6220_fixed_rate_clks,
 				ARRAY_SIZE(hi6220_fixed_rate_clks),


### PR DESCRIPTION
…init.

SYSPLL is set by bootloader. Hikey has two different bootloader rate settings due
to historical reasons. So, in order to compatible to both bootloader settings, in
kernel space, when clk init, we read the actual setting from registers.

Previously, this is assumed static and hardcoded in a static data structure.

Signed-off-by: Guodong Xu guodong.xu@linaro.org
