### PR TITLE
mailbox: Hisilicon: correct slot offset

### DIFF
--- a/drivers/mailbox/hisilicon/hi6220-mailbox.c
+++ b/drivers/mailbox/hisilicon/hi6220-mailbox.c
@@ -202,7 +202,7 @@ static void hi6220_mbox_init_hw(struct hisi_mbox_hw *mbox_hw)
 
 	for (i = 0; i < HI6220_MBOX_CHAN_NUM; i++) {
 		memcpy(&chan[i], &init_data[i], sizeof(*chan));
-		chan[i].slot = mbox_hw->buf + HI6220_MBOX_CHAN_SLOT_SIZE;
+		chan[i].slot = mbox_hw->buf + HI6220_MBOX_CHAN_SLOT_SIZE * i;
 		chan[i].mbox_hw = mbox_hw;
 	}
 


### PR DESCRIPTION
Correct code for slot offset, otherwise all channels only use
first slot.

Signed-off-by: Leo Yan leo.yan@linaro.org
