### PR TITLE
Two hdmi bug fixes

### DIFF
--- a/drivers/clk/hisilicon/clk-hi6220.c
+++ b/drivers/clk/hisilicon/clk-hi6220.c
@@ -115,6 +115,9 @@ static void __init hi6220_clk_ao_init(struct device_node *np)
 		pr_info("SYSPLL: ERROR: read returns misterious value.\n");
 		freq = 1200000000;
 	}
+
+	/* mask off freq */
+	freq -= (freq % 100000);
 	pr_info("SYSPLL: set syspll medpll: %d\n", freq);
 
 	for (i = 0; i < ARRAY_SIZE(hi6220_fixed_rate_clks); i++) {

--- a/drivers/gpu/drm/hisilicon/hisi_drm_ade.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_ade.c
@@ -362,7 +362,7 @@ static int hisi_drm_crtc_mode_set(struct drm_crtc *crtc,
 	struct hisi_drm_ade_crtc *crtc_ade = to_hisi_crtc(crtc);
 
 	DRM_DEBUG_DRIVER("mode_set  enter successfully.\n");
-	crtc_ade->dmode = adj_mode;
+	crtc_ade->dmode = mode;
 	DRM_DEBUG_DRIVER("mode_set  exit successfully.\n");
 	return 0;
 }

--- a/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
@@ -1032,12 +1032,12 @@ static int hisi_drm_connector_mode_valid(struct drm_connector *connector,
 	 * others will clear prefer
 	 */
 	vrate = mode->vrefresh = drm_mode_vrefresh(mode);
-	if ((mode->hdisplay == 1920 && mode->vdisplay == 1200 && vrate == 59) ||
+	if ((mode->hdisplay == 1920 && mode->vdisplay == 1200 && vrate == 60) ||
 	    (mode->hdisplay == 1920 && mode->vdisplay == 1080) ||
-	    (mode->hdisplay == 1680 && mode->vdisplay == 1050 && vrate == 59) ||
+	    (mode->hdisplay == 1680 && mode->vdisplay == 1050 && vrate == 60) ||
 	    (mode->hdisplay == 1280 && mode->vdisplay == 1024 && vrate == 60) ||
 	    (mode->hdisplay == 1280 && mode->vdisplay == 720 &&
-		(vrate == 60 || vrate == 59 || vrate == 50)) ||
+		(vrate == 60 || vrate == 50)) ||
 	    (mode->hdisplay == 800 && mode->vdisplay == 600 && vrate == 60))
 		mode->type |= DRM_MODE_TYPE_PREFERRED;
 	else


### PR DESCRIPTION
Fix bugs in hdmi:
1. pixel clock in 720p mode is not accurate as expected. Fixed by adjusting syspll.
2. display once enters sleep mode, cannot be waken up.
3. discard the so-called 'old 720p' mode in boxed mode list. Now only 720p and 800x600.
