### PR TITLE
arm64: dts: configure endpoints for USB tx

### DIFF
--- a/arch/arm64/boot/dts/hisilicon/hi6220.dtsi
+++ b/arch/arm64/boot/dts/hisilicon/hi6220.dtsi
@@ -1168,7 +1168,7 @@
 		g-use-dma;
 		g-rx-fifo-size = <512>;
 		g-np-tx-fifo-size = <128>;
-		g-tx-fifo-size = <128>;
+		g-tx-fifo-size = <128 128 128 128 128 128>;
 		interrupts = <0 77 0x4>;
 	};
 };


### PR DESCRIPTION
When enable ethernet on USB, found usually it will disconnect after a
while. Finally found this issue is casued by DT only configured first
endpoint; but actually etherne on USB function driver need use two
endpoints.

Signed-off-by: Leo Yan leo.yan@linaro.org
