### PR TITLE
usb: dwc2: request irq later

### DIFF
--- a/drivers/usb/dwc2/platform.c
+++ b/drivers/usb/dwc2/platform.c
@@ -247,11 +247,6 @@ static int dwc2_driver_probe(struct platform_device *dev)
 	dev_dbg(&dev->dev, "mapped PA %08lx to VA %p\n",
 		(unsigned long)res->start, hsotg->regs);
 
-	retval = devm_request_irq(hsotg->dev, irq,
-				  dwc2_handle_common_intr, IRQF_SHARED,
-				  dev_name(hsotg->dev), hsotg);
-	if (retval)
-		return retval;
 
 	hsotg->dr_mode = of_usb_get_dr_mode(dev->dev.of_node);
 
@@ -307,6 +302,12 @@ static int dwc2_driver_probe(struct platform_device *dev)
 		}
 		hsotg->hcd_enabled = 1;
 	}
+
+	retval = devm_request_irq(hsotg->dev, irq,
+				  dwc2_handle_common_intr, IRQF_SHARED,
+				  dev_name(hsotg->dev), hsotg);
+	if (retval)
+		return retval;
 
 	platform_set_drvdata(dev, hsotg);
 


### PR DESCRIPTION
Irq may happen immediately so move request irq later:
1. kernel panic may happen since hsotg->regs is not remap yet
2. gadget may return -EPROBE_DEFER
warning reported
nobody cared (try booting with the "irqpoll" option)

Signed-off-by: Zhangfei Gao zhangfei.gao@linaro.org
