### PR TITLE
Revert "mmc: hi6220: enable MMC_CAP_CMD23"

### DIFF
--- a/drivers/mmc/host/dw_mmc-k3.c
+++ b/drivers/mmc/host/dw_mmc-k3.c
@@ -30,10 +30,6 @@ struct k3_priv {
 	struct regmap	*reg;
 };
 
-static unsigned long hi6220_dwmmc_caps[] = {
-	MMC_CAP_CMD23,
-};
-
 static void dw_mci_k3_set_ios(struct dw_mci *host, struct mmc_ios *ios)
 {
 	int ret;
@@ -137,7 +133,6 @@ static int dw_mci_hi6220_execute_tunning(struct dw_mci_slot *slot)
 }
 
 static const struct dw_mci_drv_data hi6220_data = {
-	.caps			= hi6220_dwmmc_caps,
 	.switch_voltage		= dw_mci_hi6220_switch_voltage,
 	.set_ios		= dw_mci_hi6220_set_ios,
 	.parse_dt		= dw_mci_hi6220_parse_dt,


### PR DESCRIPTION
Reverts 96boards/linux#159

as it breaks wifi
