### PR TITLE
dts: hikey: fix some sd card partition not recognized

### DIFF
--- a/arch/arm64/boot/dts/hi6220.dtsi
+++ b/arch/arm64/boot/dts/hi6220.dtsi
@@ -1050,9 +1050,6 @@
 		card-detect-delay = <200>;
 		hisilicon,peripheral-syscon = <&ao_ctrl>;
 		cap-sd-highspeed;
-		sd-uhs-sdr12;
-		sd-uhs-sdr25;
-		sd-uhs-sdr50;
 		reg = <0x0 0xf723e000 0x0 0x1000>;
 		interrupts = <0x0 0x49 0x4>;
 		clocks = <&clock_sys HI6220_MMC1_CIUCLK>, <&clock_sys HI6220_MMC1_CLK>;


### PR DESCRIPTION
Some sd card be recognized SDR50 and set 1.8v, but
when read partition return -84 error so that not get
partition information.

TODO:make sure set voltage is right!

Signed-off-by: Fei Wang w.f@huawei.com
