### PR TITLE
workaround for bootup blanking issue

### DIFF
--- a/drivers/gpu/drm/hisilicon/hisi_drm_ade.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_ade.c
@@ -480,8 +480,9 @@ static int hisi_drm_crtc_mode_set_base(struct drm_crtc *crtc, int x, int y,
 	crtc_ade->res_switch_cmpl = 0;
 	writel(ADE_ENABLE, ade_base + ADE_EN_REG);
 	set_LDI_CTRL_ldi_en(ade_base, ADE_ENABLE);
-	if (wait_event_interruptible_timeout(crtc_ade->wait_res_cmpl, crtc_ade->res_switch_cmpl, HZ/4) <= 0) {
-		DRM_INFO("wait_event_interruptible_timeout wait_res_cmpl timeout!\n");
+	if (wait_event_interruptible_timeout(crtc_ade->wait_res_cmpl,
+				crtc_ade->res_switch_cmpl, HZ/4) <= 0) {
+		DRM_DEBUG_DRIVER("wait_res_cmpl timeout!\n");
 		writel(0, ade_base + ADE_SOFT_RST_SEL0_REG);
 		writel(0, ade_base + ADE_SOFT_RST_SEL1_REG);
 		writel(0xffffffff, ade_base + ADE_SOFT_RST0_REG);
@@ -625,7 +626,7 @@ static irqreturn_t ade_irq_handler(int irq, void *data)
 	/* check DMA error */
 	if ((status0 & ADE_ISR_DMA_ERROR) == ADE_ISR_DMA_ERROR) {
 		writel(ADE_ISR_DMA_ERROR, base + INTR_CLEAR_CPU_0_REG);
-		DRM_INFO("DMA error check irq\n");
+		DRM_DEBUG_DRIVER("DMA error check irq\n");
 	}
 
 	if ((status1 & ADE_ISR1_RES_SWITCH_CMPL) == ADE_ISR1_RES_SWITCH_CMPL) {
@@ -652,7 +653,7 @@ static irqreturn_t ldi_irq_handler(int irq, void *data)
 
 	if (status & LDI_ISR_UNDER_FLOW_INT) {
 		writel(LDI_ISR_UNDER_FLOW_INT, base + LDI_INT_CLR_REG);
-		DRM_INFO("underflow irq\n");
+		DRM_DEBUG_DRIVER("underflow irq\n");
 	}
 
 	return IRQ_HANDLED;
@@ -705,14 +706,14 @@ static int hisi_ade_probe(struct platform_device *pdev)
 	}
 
 	/* ade irq init */
-	ret = devm_request_irq(&pdev->dev, ade_irq, ade_irq_handler, DRIVER_IRQ_SHARED,
-			  "ade irq", crtc_ade);
+	ret = devm_request_irq(&pdev->dev, ade_irq, ade_irq_handler,
+			DRIVER_IRQ_SHARED, "ade irq", crtc_ade);
 	if (ret)
 		return ret;
 
 	/* ldi irq init */
-	ret = devm_request_irq(&pdev->dev, ldi_irq, ldi_irq_handler, DRIVER_IRQ_SHARED,
-			  "ldi irq", crtc_ade);
+	ret = devm_request_irq(&pdev->dev, ldi_irq, ldi_irq_handler,
+			DRIVER_IRQ_SHARED, "ldi irq", crtc_ade);
 	if (ret)
 		return ret;
 

--- a/drivers/gpu/drm/hisilicon/hisi_drm_drv.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_drv.c
@@ -17,7 +17,6 @@
 #include <drm/drm_gem_cma_helper.h>
 
 #include "hisi_drm_ade.h"
-#include "hisi_drm_dsi.h"
 #include "hisi_drm_fb.h"
 #ifdef CONFIG_DRM_HISI_FBDEV
 #include "hisi_drm_fbdev.h"
@@ -66,7 +65,6 @@ static int hisi_drm_sub_drivers_init(struct drm_device *drm_dev)
 
 #ifdef CONFIG_DRM_HISI_FBDEV
 /* err_fbdev_init:*/
-	hisi_drm_dsi_exit();
 #endif
 
 	return ret;

--- a/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_dsi.c
@@ -33,8 +33,6 @@
 
 #define connector_to_dsi(connector) \
 	container_of(connector, struct hisi_dsi, connector)
-#define encoder_to_dsi(encoder) \
-	container_of(encoder, struct hisi_dsi, base.base)
 
 #define DEFAULT_MIPI_CLK_RATE   19200000
 #define MAX_TX_ESC_CLK    (10)
@@ -44,64 +42,6 @@
 #define DEFAULT_MIPI_CLK_PERIOD_PS (1000000000 / (DEFAULT_MIPI_CLK_RATE / 1000))
 
 u8 *reg_base_mipi_dsi;
-
-struct mipi_dsi_phy_register {
-	u32 clk_t_lpx;
-	u32 clk_t_hs_prepare;
-	u32 clk_t_hs_zero;
-	u32 clk_t_hs_trial;
-	u32 clk_t_wakeup;
-	u32 data_t_lpx;
-	u32 data_t_hs_prepare;
-	u32 data_t_hs_zero;
-	u32 data_t_hs_trial;
-	u32 data_t_ta_go;
-	u32 data_t_ta_get;
-	u32 data_t_wakeup;
-	u32 rg_hstx_ckg_sel;
-	u32 rg_pll_fbd_div5f;
-	u32 rg_pll_fbd_div1f;
-	u32 rg_pll_fbd_2p;
-	u32 rg_pll_enbwt;
-	u32 rg_pll_fbd_p;
-	u32 rg_pll_fbd_s;
-	u32 rg_pll_pre_div1p;
-	u32 rg_pll_pre_p;
-	u32 rg_pll_vco_750M;
-	u32 rg_pll_lpf_rs;
-	u32 rg_pll_lpf_cs;
-	u32 phy_clklp2hs_time;
-	u32 phy_clkhs2lp_time;
-	u32 phy_lp2hs_time;
-	u32 phy_hs2lp_time;
-	u32 clk_to_data_delay;
-	u32 data_to_clk_delay;
-	u32 lane_byte_clk_kHz;
-	u32 clk_division;
-	u32 burst_mode;
-};
-
-struct hisi_dsi {
-	struct drm_encoder_slave base;
-	struct drm_connector connector;
-	struct i2c_client *client;
-	struct drm_i2c_encoder_driver *drm_i2c_driver;
-	struct clk *dsi_cfg_clk;
-	struct videomode vm;
-	int nominal_pixel_clock_kHz;
-
-	u8 __iomem *reg_base;
-	u8 color_mode;
-
-	u32 lanes;
-	u32 format;
-	struct mipi_dsi_phy_register phyreg;
-	u32 date_enable_pol;
-	u32 vc;
-	u32 mode_flags;
-
-	bool enable;
-};
 
 enum {
 	DSI_16BITS_1 = 0,
@@ -917,6 +857,14 @@ static void hisi_drm_encoder_disable(struct drm_encoder *encoder)
 	DRM_DEBUG_DRIVER("exit success.\n");
 }
 
+static void hisi_dsi_reset(struct drm_encoder *encoder)
+{
+	struct hisi_dsi *dsi = encoder_to_dsi(encoder);
+
+	if (dsi->enable)
+		mipi_init(dsi);
+}
+
 static struct drm_encoder_helper_funcs hisi_encoder_helper_funcs = {
 	.dpms		= hisi_drm_encoder_dpms,
 	.mode_fixup	= hisi_drm_encoder_mode_fixup,
@@ -1144,6 +1092,7 @@ static int hisi_dsi_probe(struct platform_device *pdev)
 	dsi->lanes = 3;
 	dsi->format = MIPI_DSI_FMT_RGB888;
 	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_SYNC_PULSE;
+	dsi->reset = hisi_dsi_reset;
 
 	ret = hisi_drm_encoder_create(dev, dsi);
 	if (ret) {

--- a/drivers/gpu/drm/hisilicon/hisi_drm_dsi.h
+++ b/drivers/gpu/drm/hisilicon/hisi_drm_dsi.h
@@ -12,17 +12,67 @@
 #ifndef __HISI_DRM_DSI_H__
 #define __HISI_DRM_DSI_H__
 
-#define outp32(addr, val) writel(val, addr)
-#define outp16(addr, val) writew(val, addr)
-#define outp8(addr, val) writeb(val, addr)
-#define outp(addr, val) outp32(addr, val)
+#define encoder_to_dsi(encoder) \
+	container_of(encoder, struct hisi_dsi, base.base)
 
-#define inp32(addr) readl(addr)
-#define inp16(addr) readw(addr)
-#define inp8(addr) readb(addr)
-#define inp(addr) inp32(addr)
+struct mipi_dsi_phy_register {
+	u32 clk_t_lpx;
+	u32 clk_t_hs_prepare;
+	u32 clk_t_hs_zero;
+	u32 clk_t_hs_trial;
+	u32 clk_t_wakeup;
+	u32 data_t_lpx;
+	u32 data_t_hs_prepare;
+	u32 data_t_hs_zero;
+	u32 data_t_hs_trial;
+	u32 data_t_ta_go;
+	u32 data_t_ta_get;
+	u32 data_t_wakeup;
+	u32 rg_hstx_ckg_sel;
+	u32 rg_pll_fbd_div5f;
+	u32 rg_pll_fbd_div1f;
+	u32 rg_pll_fbd_2p;
+	u32 rg_pll_enbwt;
+	u32 rg_pll_fbd_p;
+	u32 rg_pll_fbd_s;
+	u32 rg_pll_pre_div1p;
+	u32 rg_pll_pre_p;
+	u32 rg_pll_vco_750M;
+	u32 rg_pll_lpf_rs;
+	u32 rg_pll_lpf_cs;
+	u32 phy_clklp2hs_time;
+	u32 phy_clkhs2lp_time;
+	u32 phy_lp2hs_time;
+	u32 phy_hs2lp_time;
+	u32 clk_to_data_delay;
+	u32 data_to_clk_delay;
+	u32 lane_byte_clk_kHz;
+	u32 clk_division;
+	u32 burst_mode;
+};
 
-extern u8 *reg_base_mipi_dsi;
-extern int hisi_drm_dsi_init(void);
-extern void hisi_drm_dsi_exit(void);
+struct hisi_dsi {
+	struct drm_encoder_slave base;
+	struct drm_connector connector;
+	struct i2c_client *client;
+	struct drm_i2c_encoder_driver *drm_i2c_driver;
+	struct clk *dsi_cfg_clk;
+	struct videomode vm;
+	int nominal_pixel_clock_kHz;
+
+	u8 __iomem *reg_base;
+	u8 color_mode;
+
+	u32 lanes;
+	u32 format;
+	struct mipi_dsi_phy_register phyreg;
+	u32 date_enable_pol;
+	u32 vc;
+	u32 mode_flags;
+	bool enable;
+
+	/* when detect dsi transfer error call this callback to reset dsi */
+	void (*reset)(struct drm_encoder *encoder);
+};
+
 #endif /* __HISI_DRM_DSI_H__ */

--- a/drivers/gpu/drm/hisilicon/hisi_mipi_reg.h
+++ b/drivers/gpu/drm/hisilicon/hisi_mipi_reg.h
@@ -13,9 +13,18 @@
 #ifndef __HISI_MIPI_REG_H__
 #define __HISI_MIPI_REG_H__
 
-#include "hisi_drm_dsi.h"
-
+extern u8 *reg_base_mipi_dsi;
 #define get_dsi_virtual_addr()              (reg_base_mipi_dsi)
+#define outp32(addr, val) writel(val, addr)
+#define outp16(addr, val) writew(val, addr)
+#define outp8(addr, val) writeb(val, addr)
+#define outp(addr, val) outp32(addr, val)
+
+#define inp32(addr) readl(addr)
+#define inp16(addr) readw(addr)
+#define inp8(addr) readb(addr)
+#define inp(addr) inp32(addr)
+
 
 /* MIPIDSI_OFFSET_2 based on EDC: to be fixed */
 #define MIPIDSI_VERSION_ADDR                (0x0)        /* Version of the DSI host controller */


### PR DESCRIPTION
This is a workaround for bootup blanking issue.
HDMI can detect dsi transfer error, when this error happened
reseting dsi can bring display to normal.

Signed-off-by: Xinliang Liu xinliang.liu@linaro.org
