### PR TITLE
arm64: pci: add support for pci_mmap_page_range

### DIFF
--- a/arch/arm64/include/asm/pci.h
+++ b/arch/arm64/include/asm/pci.h
@@ -39,5 +39,11 @@ static inline int pci_proc_domain(struct pci_bus *bus)
 }
 #endif  /* CONFIG_PCI */
 
+#define HAVE_PCI_MMAP
+
+extern int pci_mmap_page_range(struct pci_dev *dev, struct vm_area_struct *vma,
+	enum pci_mmap_state mmap_state, int write_combine);
+
+
 #endif  /* __KERNEL__ */
 #endif  /* __ASM_PCI_H */

--- a/arch/arm64/kernel/pci.c
+++ b/arch/arm64/kernel/pci.c
@@ -68,3 +68,22 @@ int pcibus_to_node(struct pci_bus *bus)
 EXPORT_SYMBOL(pcibus_to_node);
 #endif
 
+int pci_mmap_page_range(struct pci_dev *dev, struct vm_area_struct *vma,
+		enum pci_mmap_state mmap_state, int write_combine)
+{
+	/*
+	* I/O space can be accessed via normal processor loads and stores on
+	* this platform but for now we elect not to do this and portable
+	* drivers should not do this anyway.
+	*/
+	if (mmap_state == pci_mmap_io)
+		return -EINVAL;
+
+	if (write_combine)
+		vma->vm_page_prot = pgprot_writecombine(vma->vm_page_prot);
+	else
+		vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+
+	return remap_pfn_range(vma, vma->vm_start, vma->vm_pgoff,
+	       vma->vm_end - vma->vm_start, vma->vm_page_prot);
+}


### PR DESCRIPTION
Certain X11 servers and user space network drivers frameworks
need PCI mmaped /sys/bus/pci/devices/B:D:F/resourceX file to
access PCI bar address space from user space.

Signed-off-by: Jerin Jacob jerin.jacob@caviumnetworks.com

Patch V2: http://lists.infradead.org/pipermail/linux-arm-kernel/2016-April/421948.html

Required by DPDK, so it is able to use the userspace poll mode drivers.
