### PR TITLE
drm/hisilicon: add select HISI_KIRIN_DW_DSI

### DIFF
--- a/drivers/gpu/drm/hisilicon/kirin/Kconfig
+++ b/drivers/gpu/drm/hisilicon/kirin/Kconfig
@@ -4,6 +4,7 @@ config DRM_HISI_KIRIN
 	select DRM_KMS_HELPER
 	select DRM_GEM_CMA_HELPER
 	select DRM_KMS_CMA_HELPER
+	select HISI_KIRIN_DW_DSI
 	help
 	  Choose this option if you have a hisilicon Kirin chipsets(hi6220).
 	  If M is selected the module will be called kirin-drm.


### PR DESCRIPTION
Add select HISI_KIRIN_DW_DSI to Kconfig.
The DRM driver depends on dsi_set_output_client.

Signed-off-by: Zoltan Kuscsik zoltan.kuscsik@linaro.org
